### PR TITLE
Document minimum rust version and versioning policy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,15 @@
 //!
 //! [`IndexMap`]: map/struct.IndexMap.html
 //! [`IndexSet`]: set/struct.IndexSet.html
+//!
+//!
+//! # Minimum Rust Version
+//!
+//! This version of indexmap requires Rust 1.18.
+//!
+//! The indexmap 1.0 release series will use a carefully considered version
+//! upgrade policy, where in a later 1.x version, we will raise the minimum
+//! required Rust version.
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@
 //!
 //! # Minimum Rust Version
 //!
-//! This version of indexmap requires Rust 1.18.
+//! This version of indexmap requires Rust 1.18 or later.
 //!
-//! The indexmap 1.0 release series will use a carefully considered version
+//! The indexmap 1.x release series will use a carefully considered version
 //! upgrade policy, where in a later 1.x version, we will raise the minimum
 //! required Rust version.
 


### PR DESCRIPTION
We now have indexmap 1.0!

We need to 

1. Document our version requirement (so that others can understand it and use it)
2. Make a sustainable plan for the version requirement in 1.0

I believe we can have a very long lived indexmap 1.x release series if we are careful keepers of the crate. We do then, however, have to deal with a changing Rust landscape, and whatever it will bring. I think it's best to be up front about this: I don't think we want or can stick to a Rust 1.18 minimum requirement forever. I don't either think that we should rush to new versions (I already think the Rust 1.18 requirement is a bit high for the present time, but that can be fixed backwards compatibly..)