### PR TITLE
Add `and_modify` method to `map::Entry`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -552,6 +552,19 @@ impl<'a, K, V> Entry<'a, K, V> {
             Entry::Vacant(ref entry) => entry.index(),
         }
     }
+
+    /// Modifies the entry if it is occupied.
+    pub fn and_modify<F>(self, f: F) -> Self
+        where F: FnOnce(&mut V),
+    {
+        match self {
+            Entry::Occupied(mut o) => {
+                f(o.get_mut());
+                Entry::Occupied(o)
+            }
+            x => x,
+        }
+    }
 }
 
 pub struct OccupiedEntry<'a, K: 'a, V: 'a> {
@@ -1986,5 +1999,17 @@ mod tests {
             Entry::Vacant(_) => panic!()
         }
         assert_eq!(e.or_insert("4"), &"2");
+    }
+
+    #[test]
+    fn entry_and_modify() {
+        let mut map = IndexMap::new();
+
+        map.insert(1, "1");
+        map.entry(1).and_modify(|x| *x = "2");
+        assert_eq!(Some(&"2"), map.get(&1));
+
+        map.entry(2).and_modify(|x| *x = "doesn't exist");
+        assert_eq!(None, map.get(&2));
     }
 }


### PR DESCRIPTION
First of all, thanks a lot for you lovely crate!

I'm using it for some of my pet-projects, and recently I found an [`and_modify`](https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html#method.and_modify) method missing in the map's entry API.

My personal use-case is as following: I use a structure like `HashMap<_, NonEmptySet<_>>`, and I need to insert something into that `NonEmptySet`. Since I can't use the `or_insert_with` method (I can't create an empty `NonEmptySet` :) ), I have to first match whether an `Entry` is vacant and manually create a `NonEmptySet` with my element or insert the element into an already existing set if the entry is occupied.

With `and_modify` I can skip the matching part and write something like that:

```rust
mymap
    .entry(key)
    .and_modify(|non_empty_set| {
        non_empty_set.insert(some_stuff);
    }).or_insert_with(|| NonEmptySet::new(some_stuff));
```

... which is a little bit simpler than using `match entry() { Vacant(...) => ...`.

For my personal needs I'm using an extension trait, but I thought it might be a good idea to implement the method for the indexmap itself.

Thanks for you attention :)