### PR TITLE
Downgrade lazy_static for Rust 1.18 CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: false
 matrix:
   include:
     - rust: 1.18.0
+      before_script:
+        # lazy_static 1.1 requires Rust 1.21+, so downgrade it.
+        # (we only use it in benchmarks anyway...)
+        - cargo generate-lockfile
+        - cargo update -p lazy_static --precise 1.0.2
     - rust: stable
       env:
        - FEATURES='serde-1'


### PR DESCRIPTION
In `lazy_static 1.1`, they now require Rust 1.21.  We only use it for
benchmarks anyway, but all dev-dependencies still have to be built for
testing.