### PR TITLE
Additional operations for manipulating iteration order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ## Rust Version
 //!
-//! This version of indexmap requires Rust 1.18 or later.
+//! This version of indexmap requires Rust 1.26 or later.
 //!
 //! The indexmap 1.x release series will use a carefully considered version
 //! upgrade policy, where in a later 1.x version, we will raise the minimum


### PR DESCRIPTION
This PR adds operations to `IndexMap` (and `IndexSet`) that allow an entry to be moved to a specific position in the iteration order, while preserving the order of all other entries. The operation's average computation time is proportional to the distance between the entry's current position and the new position, assuming that probing the hash table takes constant time on average.

The PR requires an upgrade to Rust version 1.26, because it relies on the `rotate_left` and `rotate_right` methods of the slice type. If upgrading to 1.26 is deemed inappropriate at this time, it may be necessary to delay merging this PR.

The new operations also may allow for an alternative implementation of `ordered_remove` (from PR #15), in which the element being removed is first moved to the end of the ordering, then `IndexMap::pop()` is called. This might be more efficient if the element to be removed is already close to the end. I haven't included that idea in the PR, but it could be considered if the PR is accepted.

Please let me know if you find any problems in the PR that I need to fix. One thing I am unsure about is whether returning `Option<()>` is or is not an appropriate/idiomatic way of supporting error detection in a method that wouldn't normally return anything.

### Use Case
My use case for this PR is that I am planning to create a GUI application where the user can manage a list of items, including reordering the items by dragging and dropping an item in the list. Internally, the items may reference each other by a unique key. Ideally, I want to be able to look up an item efficiently by both its numerical index and its unique key. IndexMap seems like a good fit for this use case, and this PR would make it easier for me to implement the reordering through drag and drop.