### PR TITLE
Update quickcheck to 0.7 and rand to 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
         # (we only use it in benchmarks anyway...)
         - cargo generate-lockfile
         - cargo update -p lazy_static --precise 1.0.2
+    - rust: 1.22.1
     - rust: stable
       env:
        - FEATURES='serde-1'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 itertools = "0.7.0"
-rand = "0.4"
-quickcheck = { version = "0.6", default-features = false }
+rand = "0.5"
+quickcheck = { version = "0.7", default-features = false }
 fnv = "1.0"
 lazy_static = "1"
 serde_test = "1.0.5"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -20,7 +20,12 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::iter::FromIterator;
 
-use rand::{weak_rng, Rng};
+use rand::{thread_rng, Rng, SeedableRng};
+use rand::rngs::SmallRng;
+
+fn weak_rng() -> SmallRng {
+    SmallRng::from_rng(thread_rng()).unwrap()
+}
 
 #[bench]
 fn new_hashmap(b: &mut Bencher) {

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -3,6 +3,7 @@ extern crate indexmap;
 extern crate itertools;
 #[macro_use]
 extern crate quickcheck;
+extern crate rand;
 
 extern crate fnv;
 
@@ -11,6 +12,7 @@ use itertools::Itertools;
 
 use quickcheck::Arbitrary;
 use quickcheck::Gen;
+use rand::Rng;
 
 use fnv::FnvHasher;
 use std::hash::{BuildHasher, BuildHasherDefault};


### PR DESCRIPTION
Potentially upgrade these deps. Rand will require Rust 1.22, but it's only used for testing, so it could be moved to a separate testing crate that doesn't run for earlier versions.