### PR TITLE
Enable use from no_std crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ bench = false
 
 [dependencies]
 serde = { version = "1.0", optional = true }
+hashmap_core = { version = "0.1.10", optional = true }
 
 [dev-dependencies]
 itertools = "0.7.0" # 0.8 not compiles on Rust 1.18
@@ -39,6 +40,10 @@ lazy_static = "1"
 serde_test = "1.0.5"
 
 [features]
+default = ["std"]
+std = []
+core = ["hashmap_core"]
+
 # Serialization with serde 1.0
 serde-1 = ["serde"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,34 @@
 //! upgrade policy, where in a later 1.x version, we will raise the minimum
 //! required Rust version.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+extern crate hashmap_core;
+
+#[cfg(not(feature = "std"))]
+mod std {
+    pub use core::*;
+
+    pub mod vec {
+        pub use alloc::vec::*;
+    }
+
+    pub mod boxed {
+        pub use alloc::boxed::*;
+    }
+
+    pub mod collections {
+        pub mod hash_map {
+            pub use hashmap_core::map::*;
+        }
+    }
+}
+
 #[macro_use]
 mod macros;
 #[cfg(feature = "serde-1")]

--- a/src/map.rs
+++ b/src/map.rs
@@ -9,6 +9,8 @@ use std::hash::Hasher;
 use std::iter::FromIterator;
 use std::collections::hash_map::RandomState;
 use std::ops::RangeFull;
+use std::boxed::Box;
+use std::vec::Vec;
 
 use std::cmp::{max, Ordering};
 use std::fmt;


### PR DESCRIPTION
This PR adds the ability to use this crate with `no_std`. It has no breaking changes, using a default `std` feature with an optional `core` feature. Since `HashMap` is only included in `libstd`, it uses the `hashmap_core` crate to replace it when compiling with `no_std`.

It may be cleaner to replace uses of `std` with `core` or `alloc`, rather than creating a fake `std`. Please let me know if you'd prefer that.