### PR TITLE
Update development dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ language: rust
 sudo: false
 matrix:
   include:
+    # MSRV is lower for non-dev builds
     - rust: 1.18.0
-      before_script:
-        # lazy_static 1.1 requires Rust 1.21+, so downgrade it.
-        # (we only use it in benchmarks anyway...)
-        - cargo generate-lockfile
-        - cargo update -p lazy_static --precise 1.0.2
+      env:
+       - SKIP_TEST=1
+    - rust: 1.30.0
     - rust: stable
       env:
        - FEATURES='serde-1'
@@ -22,6 +21,8 @@ branches:
 script:
   - |
       cargo build --verbose --features "$FEATURES" &&
-      cargo test --verbose --features "$FEATURES" &&
-      cargo test --release --verbose --features "$FEATURES" &&
+      if [ -z "$SKIP_TEST" ]; then
+        cargo test --verbose --features "$FEATURES" &&
+        cargo test --release --verbose --features "$FEATURES"
+      fi &&
       cargo doc --verbose --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,12 @@ bench = false
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
-itertools = "0.7.0" # 0.8 not compiles on Rust 1.18
-rand = "0.4"
-quickcheck = { version = "0.6", default-features = false }
+itertools = "0.8"
+rand = "0.6"
+quickcheck = { version = "0.8", default-features = false }
 fnv = "1.0"
-lazy_static = "1"
-serde_test = "1.0.5"
+lazy_static = "1.3"
+serde_test = "1.0.99"
 
 [features]
 # Serialization with serde 1.0

--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,8 @@ Recent Changes
 
   - Serde trait ``IntoDeserializer`` are implemented for ``IndexMap`` and ``IndexSet``.
 
+  - Minimum Rust version requirement increased to Rust 1.30 for development builds.
+
 - 1.0.2
 
   - The new methods ``IndexMap::insert_full`` and ``IndexSet::insert_full`` are

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@
 //!
 //! ## Rust Version
 //!
-//! This version of indexmap requires Rust 1.18 or later.
+//! This version of indexmap requires Rust 1.18 or later, or 1.30+ for
+//! development builds.
 //!
 //! The indexmap 1.x release series will use a carefully considered version
 //! upgrade policy, where in a later 1.x version, we will raise the minimum

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -3,6 +3,7 @@ extern crate indexmap;
 extern crate itertools;
 #[macro_use]
 extern crate quickcheck;
+extern crate rand;
 
 extern crate fnv;
 
@@ -11,6 +12,8 @@ use itertools::Itertools;
 
 use quickcheck::Arbitrary;
 use quickcheck::Gen;
+
+use rand::Rng;
 
 use fnv::FnvHasher;
 use std::hash::{BuildHasher, BuildHasherDefault};


### PR DESCRIPTION
Also update the travis script and the README to indicate that MSRV is
1.18 for builds, and 1.30 for development builds.

Fixes #96.