### PR TITLE
Expand removal options

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -574,7 +574,7 @@ fn ordermap_merge_shuffle(b: &mut Bencher) {
 }
 
 #[bench]
-fn remove_ordermap_100_000(b: &mut Bencher) {
+fn swap_remove_ordermap_100_000(b: &mut Bencher) {
     let map = OMAP_100K.clone();
     let mut keys = Vec::from_iter(map.keys().cloned());
     let mut rng = SmallRng::from_entropy();
@@ -584,6 +584,44 @@ fn remove_ordermap_100_000(b: &mut Bencher) {
         let mut map = map.clone();
         for key in &keys {
             map.swap_remove(key);
+        }
+        assert_eq!(map.len(), 0);
+        map
+    });
+}
+
+#[bench]
+fn shift_remove_ordermap_100_000_few(b: &mut Bencher) {
+    let map = OMAP_100K.clone();
+    let mut keys = Vec::from_iter(map.keys().cloned());
+    let mut rng = SmallRng::from_entropy();
+    keys.shuffle(&mut rng);
+    keys.truncate(50);
+
+    b.iter(|| {
+        let mut map = map.clone();
+        for key in &keys {
+            map.shift_remove(key);
+        }
+        assert_eq!(map.len(), OMAP_100K.len() - keys.len());
+        map
+    });
+}
+
+#[bench]
+fn shift_remove_ordermap_2_000_full(b: &mut Bencher) {
+    let mut keys = KEYS[..2_000].to_vec();
+    let mut map = IndexMap::with_capacity(keys.len());
+    for &key in &keys {
+        map.insert(key, key);
+    }
+    let mut rng = SmallRng::from_entropy();
+    keys.shuffle(&mut rng);
+
+    b.iter(|| {
+        let mut map = map.clone();
+        for key in &keys {
+            map.shift_remove(key);
         }
         assert_eq!(map.len(), 0);
         map

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -583,7 +583,7 @@ fn remove_ordermap_100_000(b: &mut Bencher) {
     b.iter(|| {
         let mut map = map.clone();
         for key in &keys {
-            map.remove(key);
+            map.swap_remove(key);
         }
         assert_eq!(map.len(), 0);
         map

--- a/src/map.rs
+++ b/src/map.rs
@@ -664,6 +664,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
         replace(self.get_mut(), value)
     }
 
+    #[deprecated(note = "use `swap_remove`")]
     pub fn remove(self) -> V {
         self.swap_remove()
     }
@@ -680,6 +681,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     }
 
     /// Remove and return the key, value pair stored in the map for this entry
+    #[deprecated(note = "use `swap_remove_entry`")]
     pub fn remove_entry(self) -> (K, V) {
         self.swap_remove_entry()
     }
@@ -977,6 +979,7 @@ impl<K, V, S> IndexMap<K, V, S>
     /// NOTE: Same as .swap_remove
     ///
     /// Computes in **O(1)** time (average).
+    #[deprecated(note = "use `swap_remove`")]
     pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
         where Q: Hash + Equivalent<K>,
     {
@@ -2173,7 +2176,7 @@ mod tests {
         map_a.insert(2, "2");
         let mut map_b = map_a.clone();
         assert_eq!(map_a, map_b);
-        map_b.remove(&1);
+        map_b.swap_remove(&1);
         assert_ne!(map_a, map_b);
 
         let map_c: IndexMap<_, String> = map_b.into_iter().map(|(k, v)| (k, v.to_owned())).collect();

--- a/src/map.rs
+++ b/src/map.rs
@@ -670,7 +670,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
 
     /// Remove and return the key, value pair stored in the map for this entry
     pub fn remove_entry(self) -> (K, V) {
-        self.map.remove_found(self.probe, self.index)
+        self.map.swap_remove_found(self.probe, self.index)
     }
 }
 
@@ -992,7 +992,7 @@ impl<K, V, S> IndexMap<K, V, S>
             None => return None,
             Some(t) => t,
         };
-        let (k, v) = self.core.remove_found(probe, found);
+        let (k, v) = self.core.swap_remove_found(probe, found);
         Some((found, k, v))
     }
 
@@ -1111,7 +1111,7 @@ impl<K, V, S> IndexMap<K, V, S> {
             None => return None,
             Some(t) => t,
         };
-        Some(self.core.remove_found(probe, found))
+        Some(self.core.swap_remove_found(probe, found))
     }
 }
 
@@ -1225,7 +1225,7 @@ impl<K, V> OrderMapCore<K, V> {
             Some(t) => t,
         };
         debug_assert_eq!(found, self.entries.len() - 1);
-        Some(self.remove_found(probe, found))
+        Some(self.swap_remove_found(probe, found))
     }
 
     // FIXME: reduce duplication (compare with insert)
@@ -1375,11 +1375,11 @@ impl<K, V> OrderMapCore<K, V> {
         (probe, actual_pos)
     }
 
-    fn remove_found(&mut self, probe: usize, found: usize) -> (K, V) {
-        dispatch_32_vs_64!(self.remove_found_impl(probe, found))
+    fn swap_remove_found(&mut self, probe: usize, found: usize) -> (K, V) {
+        dispatch_32_vs_64!(self.swap_remove_found_impl(probe, found))
     }
 
-    fn remove_found_impl<Sz>(&mut self, probe: usize, found: usize) -> (K, V)
+    fn swap_remove_found_impl<Sz>(&mut self, probe: usize, found: usize) -> (K, V)
         where Sz: Size
     {
         // index `probe` and entry `found` is to be removed

--- a/src/map.rs
+++ b/src/map.rs
@@ -665,11 +665,33 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     }
 
     pub fn remove(self) -> V {
-        self.remove_entry().1
+        self.swap_remove()
+    }
+
+    /// Remove the key, value pair stored in the map for this entry, and return the value.
+    ///
+    /// Like `Vec::swap_remove`, the pair is removed by swapping it with the
+    /// last element of the map and popping it off. **This perturbs
+    /// the postion of what used to be the last element!**
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn swap_remove(self) -> V {
+        self.swap_remove_entry().1
     }
 
     /// Remove and return the key, value pair stored in the map for this entry
     pub fn remove_entry(self) -> (K, V) {
+        self.swap_remove_entry()
+    }
+
+    /// Remove and return the key, value pair stored in the map for this entry
+    ///
+    /// Like `Vec::swap_remove`, the pair is removed by swapping it with the
+    /// last element of the map and popping it off. **This perturbs
+    /// the postion of what used to be the last element!**
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn swap_remove_entry(self) -> (K, V) {
         self.map.swap_remove_found(self.probe, self.index)
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -349,6 +349,7 @@ impl<T, S> IndexSet<T, S>
     /// FIXME Same as .swap_take
     ///
     /// Computes in **O(1)** time (average).
+    #[deprecated(note = "use `swap_take` or `shift_take`")]
     pub fn take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
         where Q: Hash + Equivalent<T>,
     {
@@ -369,6 +370,22 @@ impl<T, S> IndexSet<T, S>
         where Q: Hash + Equivalent<T>,
     {
         self.map.swap_remove_full(value).map(|(_, x, ())| x)
+    }
+
+    /// Removes and returns the value in the set, if any, that is equal to the
+    /// given one.
+    ///
+    /// Like `Vec::remove`, the value is removed by shifting all of the
+    /// elements that follow it, preserving their relative order.
+    /// **This perturbs the index of all of those elements!**
+    ///
+    /// Return `None` if `value` was not in the set.
+    ///
+    /// Computes in **O(n)** time (average).
+    pub fn shift_take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
+        where Q: Hash + Equivalent<T>,
+    {
+        self.map.shift_remove_full(value).map(|(_, x, ())| x)
     }
 
     /// Remove the value from the set return it and the index it had.

--- a/src/set.rs
+++ b/src/set.rs
@@ -309,7 +309,7 @@ impl<T, S> IndexSet<T, S>
     /// FIXME Same as .swap_remove
     ///
     /// Computes in **O(1)** time (average).
-    #[deprecated(note = "use `swap_remove`")]
+    #[deprecated(note = "use `swap_remove` or `shift_remove`")]
     pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
         where Q: Hash + Equivalent<T>,
     {
@@ -329,6 +329,21 @@ impl<T, S> IndexSet<T, S>
         where Q: Hash + Equivalent<T>,
     {
         self.map.swap_remove(value).is_some()
+    }
+
+    /// Remove the value from the set, and return `true` if it was present.
+    ///
+    /// Like `Vec::remove`, the value is removed by shifting all of the
+    /// elements that follow it, preserving their relative order.
+    /// **This perturbs the index of all of those elements!**
+    ///
+    /// Return `false` if `value` was not in the set.
+    ///
+    /// Computes in **O(n)** time (average).
+    pub fn shift_remove<Q: ?Sized>(&mut self, value: &Q) -> bool
+        where Q: Hash + Equivalent<T>,
+    {
+        self.map.shift_remove(value).is_some()
     }
 
     /// FIXME Same as .swap_take
@@ -367,6 +382,19 @@ impl<T, S> IndexSet<T, S>
         where Q: Hash + Equivalent<T>,
     {
         self.map.swap_remove_full(value).map(|(i, x, ())| (i, x))
+    }
+
+    /// Remove the value from the set return it and the index it had.
+    ///
+    /// Like `Vec::remove`, the value is removed by shifting all of the
+    /// elements that follow it, preserving their relative order.
+    /// **This perturbs the index of all of those elements!**
+    ///
+    /// Return `None` if `value` was not in the set.
+    pub fn shift_remove_full<Q: ?Sized>(&mut self, value: &Q) -> Option<(usize, T)>
+        where Q: Hash + Equivalent<T>,
+    {
+        self.map.shift_remove_full(value).map(|(i, x, ())| (i, x))
     }
 
     /// Remove the last value
@@ -442,9 +470,26 @@ impl<T, S> IndexSet<T, S> {
     ///
     /// Valid indices are *0 <= index < self.len()*
     ///
+    /// Like `Vec::swap_remove`, the value is removed by swapping it with the
+    /// last element of the set and popping it off. **This perturbs
+    /// the postion of what used to be the last element!**
+    ///
     /// Computes in **O(1)** time (average).
     pub fn swap_remove_index(&mut self, index: usize) -> Option<T> {
         self.map.swap_remove_index(index).map(|(x, ())| x)
+    }
+
+    /// Remove the key-value pair by index
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    ///
+    /// Like `Vec::remove`, the value is removed by shifting all of the
+    /// elements that follow it, preserving their relative order.
+    /// **This perturbs the index of all of those elements!**
+    ///
+    /// Computes in **O(n)** time (average).
+    pub fn shift_remove_index(&mut self, index: usize) -> Option<T> {
+        self.map.shift_remove_index(index).map(|(x, ())| x)
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -309,6 +309,7 @@ impl<T, S> IndexSet<T, S>
     /// FIXME Same as .swap_remove
     ///
     /// Computes in **O(1)** time (average).
+    #[deprecated(note = "use `swap_remove`")]
     pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
         where Q: Hash + Equivalent<T>,
     {
@@ -1193,7 +1194,7 @@ mod tests {
         set_a.insert(2);
         let mut set_b = set_a.clone();
         assert_eq!(set_a, set_b);
-        set_b.remove(&1);
+        set_b.swap_remove(&1);
         assert_ne!(set_a, set_b);
 
         let set_c: IndexSet<_> = set_b.into_iter().collect();

--- a/tests/equivalent_trait.rs
+++ b/tests/equivalent_trait.rs
@@ -51,5 +51,5 @@ fn test_string_str() {
 
     assert!(map.contains_key("a"));
     assert!(!map.contains_key("z"));
-    assert_eq!(map.remove("b"), Some(2));
+    assert_eq!(map.swap_remove("b"), Some(2));
 }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -116,7 +116,7 @@ quickcheck! {
         let mut clone = map.clone();
         let drained = clone.drain(..);
         for (key, _) in drained {
-            map.remove(&key);
+            map.swap_remove(&key);
         }
         map.is_empty()
     }
@@ -166,7 +166,7 @@ fn do_ops<K, V, S>(ops: &[Op<K, V>], a: &mut IndexMap<K, V, S>, b: &mut HashMap<
             }
             RemoveEntry(ref k) => {
                 match a.entry(k.clone()) {
-                    OEntry::Occupied(ent) => { ent.remove_entry(); },
+                    OEntry::Occupied(ent) => { ent.swap_remove_entry(); },
                     _ => { }
                 }
                 match b.entry(k.clone()) {


### PR DESCRIPTION
This aims to make the performance tradeoffs explicit when removing items.

- New `shift_remove` and `shift_take` perform O(n) removal, like `Vec::remove`
- The existing `swap_*` methods already perform like `Vec::swap_remove`
- Ambiguous `remove` and `take` methods, which currently swap, are deprecated in favor of explicit `shift`/`swap` methods.

Fixes #90.