### PR TITLE
Fix self-referential usage in indexmap/indexset macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,5 @@
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 /// Create an `IndexMap` from a list of key-value pairs
 ///
 /// ## Example
@@ -37,7 +37,7 @@ macro_rules! indexmap {
     };
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 /// Create an `IndexSet` from a list of values
 ///
 /// ## Example

--- a/tests/macros_full_path.rs
+++ b/tests/macros_full_path.rs
@@ -1,0 +1,21 @@
+
+#[test]
+fn test_create_map() {
+    let _m = indexmap::indexmap! {
+        1 => 2,
+        7 => 1,
+        2 => 2,
+        3 => 3,
+    };
+}
+
+
+#[test]
+fn test_create_set() {
+    let _s = indexmap::indexset! {
+        1,
+        7,
+        2,
+        3,
+    };
+}


### PR DESCRIPTION
This was just fixed in maplit, so copying the same fix to here.

The attribute option fixes the self-referential usage of the macro in
itself, and fixes the macros so they can be used with their full path
(like indexmap::indexmap!(), see tests).

This is backwards compatible, see
https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html#local-helper-macros
for more information.