### PR TITLE
Support building without libstd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,15 @@ matrix:
     - rust: nightly
       env:
        - FEATURES='test_low_transition_point'
-    - name: "no_std"
-      rust: stable
+    - rust: 1.36.0
+      env: TARGET=thumbv6m-none-eabi
+      before_script:
+        - rustup target add $TARGET
+        - set -ex
+      script:
+        - cargo build -vv --target=$TARGET
+        - cargo build -v -p test-nostd --target=$TARGET
+    - rust: stable
       env: TARGET=thumbv6m-none-eabi
       before_script:
         - rustup target add $TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,15 @@ matrix:
     - rust: nightly
       env:
        - FEATURES='test_low_transition_point'
+    - name: "no_std"
+      rust: stable
+      env: TARGET=thumbv6m-none-eabi
+      before_script:
+        - rustup target add $TARGET
+        - set -ex
+      script:
+        - cargo build -vv --target=$TARGET
+        - cargo build -v -p test-nostd --target=$TARGET
 branches:
   only:
     - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ This crate was initially published under the name ordermap, but it was renamed t
 indexmap.
 """
 
-keywords = ["hashmap"]
-categories = ["data-structures"]
+keywords = ["hashmap", "no_std"]
+categories = ["data-structures", "no-std"]
 
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,13 @@ indexmap.
 keywords = ["hashmap"]
 categories = ["data-structures"]
 
+build = "build.rs"
+
 [lib]
 bench = false
 
+[build-dependencies]
+autocfg = "0.1.6"
 [dependencies]
 serde = { version = "1.0", optional = true }
 rayon = { version = "1.0", optional = true }
@@ -56,3 +60,6 @@ tag-name = "{{version}}"
 
 [package.metadata.docs.rs]
 features = ["serde-1", "rayon"]
+
+[workspace]
+members = ["test-nostd"]

--- a/build.rs
+++ b/build.rs
@@ -3,4 +3,5 @@ extern crate autocfg;
 fn main() {
     let ac = autocfg::new();
     ac.emit_sysroot_crate("std");
+    autocfg::rerun_path(file!());
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+extern crate autocfg;
+
+fn main() {
+    let ac = autocfg::new();
+    ac.emit_sysroot_crate("std");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,34 @@
 //! [`IndexSet`]: set/struct.IndexSet.html
 //!
 //!
+//!
 //! ## Rust Version
 //!
 //! This version of indexmap requires Rust 1.18 or later, or 1.30+ for
-//! development builds.
+//! development builds, and Rust 1.36+ for using with `alloc` (without `std`),
+//! see below.
 //!
 //! The indexmap 1.x release series will use a carefully considered version
 //! upgrade policy, where in a later 1.x version, we will raise the minimum
 //! required Rust version.
+//!
+//! ## No Standard Library Targets
+//!
+//! From Rust 1.36, this crate supports being built without `std`, requiring
+//! `alloc` instead. This is enabled automatically when it is detected that
+//! `std` is not available. There is no crate feature to enable/disable to
+//! trigger this. It can be tested by building for a std-less target.
+//!
+//! - Creating maps and sets using [`new`][IndexMap::new] and
+//! [`with_capacity`][IndexMap::with_capacity] is unavailable without `std`.  
+//!   Use methods [`IndexMap::default`][def],
+//!   [`with_hasher`][IndexMap::with_hasher],
+//!   [`with_capacity_and_hasher`][IndexMap::with_capacity_and_hasher] instead.
+//!   A no-std compatible hasher will be needed as well, for example
+//!   from the crate `twox-hash`.
+//! - Macros [`indexmap!`] and [`indexset!`] are unavailable without `std`.
+//!
+//! [def]: map/struct.IndexMap.html#impl-Default
 
 #[cfg(not(has_std))]
 #[macro_use(vec)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-
 #![deny(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/indexmap/1/")]
+#![cfg_attr(not(has_std), no_std)]
 
 //! [`IndexMap`] is a hash table where the iteration order of the key-value
 //! pairs is independent of the hash values of the keys.
@@ -20,6 +20,25 @@
 //! The indexmap 1.x release series will use a carefully considered version
 //! upgrade policy, where in a later 1.x version, we will raise the minimum
 //! required Rust version.
+
+#[cfg(not(has_std))]
+#[macro_use(vec)]
+extern crate alloc;
+
+#[cfg(not(has_std))]
+pub(crate) mod std {
+    pub use core::*;
+    pub mod alloc {
+        pub use ::alloc::*;
+    }
+    pub mod collections {
+        pub use ::alloc::collections::*;
+    }
+    pub use ::alloc::vec as vec;
+}
+
+#[cfg(not(has_std))]
+use std::vec::Vec;
 
 #[macro_use]
 mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,5 @@
 
+#[cfg(has_std)]
 #[macro_export(local_inner_macros)]
 /// Create an `IndexMap` from a list of key-value pairs
 ///
@@ -37,6 +38,7 @@ macro_rules! indexmap {
     };
 }
 
+#[cfg(has_std)]
 #[macro_export(local_inner_macros)]
 /// Create an `IndexSet` from a list of values
 ///

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,6 +1,11 @@
 //! `IndexMap` is a hash table where the iteration order of the key-value
 //! pairs is independent of the hash values of the keys.
 
+#[cfg(not(has_std))]
+use alloc::boxed::Box;
+#[cfg(not(has_std))]
+use std::vec::Vec;
+
 pub use mutable_keys::MutableKeys;
 
 #[cfg(feature = "rayon")]
@@ -10,8 +15,10 @@ use std::hash::Hash;
 use std::hash::BuildHasher;
 use std::hash::Hasher;
 use std::iter::FromIterator;
-use std::collections::hash_map::RandomState;
 use std::ops::RangeFull;
+
+#[cfg(has_std)]
+use std::collections::hash_map::RandomState;
 
 use std::cmp::{max, Ordering};
 use std::fmt;
@@ -264,7 +271,14 @@ impl<Sz> ShortHashProxy<Sz>
 /// assert_eq!(letters.get(&'y'), None);
 /// ```
 #[derive(Clone)]
+#[cfg(has_std)]
 pub struct IndexMap<K, V, S = RandomState> {
+    core: OrderMapCore<K, V>,
+    hash_builder: S,
+}
+#[derive(Clone)]
+#[cfg(not(has_std))]
+pub struct IndexMap<K, V, S> {
     core: OrderMapCore<K, V>,
     hash_builder: S,
 }
@@ -379,6 +393,7 @@ macro_rules! probe_loop {
     }
 }
 
+#[cfg(has_std)]
 impl<K, V> IndexMap<K, V> {
     /// Create a new map. (Does not allocate.)
     pub fn new() -> Self {

--- a/src/set.rs
+++ b/src/set.rs
@@ -3,8 +3,13 @@
 #[cfg(feature = "rayon")]
 pub use ::rayon::set as rayon;
 
-use std::cmp::Ordering;
+#[cfg(not(has_std))]
+use std::vec::Vec;
+
+#[cfg(has_std)]
 use std::collections::hash_map::RandomState;
+
+use std::cmp::Ordering;
 use std::fmt;
 use std::iter::{FromIterator, Chain};
 use std::hash::{Hash, BuildHasher};
@@ -59,7 +64,13 @@ type Bucket<T> = super::Bucket<T, ()>;
 /// assert!(!letters.contains(&'y'));
 /// ```
 #[derive(Clone)]
+#[cfg(has_std)]
 pub struct IndexSet<T, S = RandomState> {
+    map: IndexMap<T, (), S>,
+}
+#[cfg(not(has_std))]
+#[derive(Clone)]
+pub struct IndexSet<T, S> {
     map: IndexMap<T, (), S>,
 }
 
@@ -99,6 +110,7 @@ impl<T, S> fmt::Debug for IndexSet<T, S>
     }
 }
 
+#[cfg(has_std)]
 impl<T> IndexSet<T> {
     /// Create a new set. (Does not allocate.)
     pub fn new() -> Self {

--- a/test-nostd/Cargo.toml
+++ b/test-nostd/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "test-nostd"
+version = "0.1.0"
+authors = ["bluss"]
+publish = false
+
+[dependencies]
+indexmap = { path = ".." }
+# no-std compatible hasher
+ahash = "0.2"
+
+[dev-dependencies]

--- a/test-nostd/Cargo.toml
+++ b/test-nostd/Cargo.toml
@@ -3,10 +3,11 @@ name = "test-nostd"
 version = "0.1.0"
 authors = ["bluss"]
 publish = false
+edition = "2018"
 
 [dependencies]
 indexmap = { path = ".." }
 # no-std compatible hasher
-ahash = "0.2"
+twox-hash = { version = "1.5", default-features = false }
 
 [dev-dependencies]

--- a/test-nostd/src/lib.rs
+++ b/test-nostd/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+
+extern crate indexmap;
+extern crate ahash;
+
+use indexmap::IndexMap;
+use indexmap::IndexSet;
+type Map<K, V> = IndexMap<K, V, ahash::ABuildHasher>;
+type Set<T> = IndexSet<T, ahash::ABuildHasher>;
+
+use core::iter::FromIterator;
+
+pub fn test_compile() {
+    let mut map = Map::default();
+    map.insert(1, 1);
+    map.insert(2, 4);
+    for (_, _) in map.iter() { }
+
+    let _map2 = Map::from_iter(Some((1, 1)));
+
+    let mut set = Set::default();
+    set.insert("a");
+}

--- a/test-nostd/src/lib.rs
+++ b/test-nostd/src/lib.rs
@@ -1,12 +1,11 @@
 #![no_std]
 
-extern crate indexmap;
-extern crate ahash;
-
 use indexmap::IndexMap;
 use indexmap::IndexSet;
-type Map<K, V> = IndexMap<K, V, ahash::ABuildHasher>;
-type Set<T> = IndexSet<T, ahash::ABuildHasher>;
+use core::hash::BuildHasherDefault;
+use twox_hash::XxHash64;
+type Map<K, V> = IndexMap<K, V, BuildHasherDefault<XxHash64>>;
+type Set<T> = IndexSet<T, BuildHasherDefault<XxHash64>>;
 
 use core::iter::FromIterator;
 


### PR DESCRIPTION
Recast version of #95 by @leo60228

1. Continue supporting current Rust versions in the default configuration
2. On targets where std is missing, compile as no_std using the feature detection leo added in autocfg (Requires Rust 1.36)
3. There's no feature flag for this, because it's not needed (negative feature flags being awkward), and because it could be considered to be a breaking change
4. Constructor `new` etc is not available without std — one has to use the others like `with_hasher` or `default`. The `indexmap!` macros depend on these as well, and require std too.

This approach, in particular (3) is novel, and thus it is out for wider requests for comments.

A no-std indexmap has been requested by petgraph.

Fixes #94 
Closes #95 
Closes #92 