### PR TITLE
Adds entry_index to map.rs

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1032,7 +1032,7 @@ where
     }
 
     /// Return item index
-    pub fn get_index<Q: ?Sized>(&self, key: &Q) -> Option<usize>
+    pub fn entry_index<Q: ?Sized>(&self, key: &Q) -> Option<usize>
     where
         Q: Hash + Equivalent<K>,
     {

--- a/src/map.rs
+++ b/src/map.rs
@@ -1037,7 +1037,6 @@ where
         Q: Hash + Equivalent<K>,
     {
         if let Some((_, found)) = self.find(key) {
-            let entry = &self.core.entries[found];
             Some(found)
         } else {
             None

--- a/src/map.rs
+++ b/src/map.rs
@@ -1031,6 +1031,19 @@ where
         }
     }
 
+    /// Return item index
+    pub fn get_index<Q: ?Sized>(&self, key: &Q) -> Option<usize>
+    where
+        Q: Hash + Equivalent<K>,
+    {
+        if let Some((_, found)) = self.find(key) {
+            let entry = &self.core.entries[found];
+            Some(found)
+        } else {
+            None
+        }
+    }
+
     pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V>
     where
         Q: Hash + Equivalent<K>,

--- a/src/set.rs
+++ b/src/set.rs
@@ -327,6 +327,14 @@ where
         self.map.get_full(value).map(|(i, x, &())| (i, x))
     }
 
+    /// Return item index
+    pub fn entry_index<Q: ?Sized>(&self, value: &Q) -> Option<(usize)>
+    where
+        Q: Hash + Equivalent<T>,
+    {
+        self.map.entry_index(value)
+    }
+
     /// Adds a value to the set, replacing the existing value, if any, that is
     /// equal to the given one. Returns the replaced value.
     ///


### PR DESCRIPTION
I wanted a way to access the index but the only way to do that is  by getting the entry and then the index from that which is mutable (and causes issues) or from `get_full` which returns more than what I needed so I added `entry_index`