### PR TITLE
Use a plain relative path for autocfg::rerun_path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,5 +3,5 @@ extern crate autocfg;
 fn main() {
     let ac = autocfg::new();
     ac.emit_sysroot_crate("std");
-    autocfg::rerun_path(file!());
+    autocfg::rerun_path("build.rs");
 }


### PR DESCRIPTION
Fixes #123.