### PR TITLE
Unify the entry and insert code

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1700,7 +1700,7 @@ trait ProbeAction<'a, Sz: Size, K, V>: Sized {
     fn hit(self, entry: OccupiedEntry<'a, K, V>) -> Self::Output;
     // handle an empty spot in the map
     fn empty(self, entry: VacantEntry<'a, K, V>) -> Self::Output;
-    // robin hood: handle a that you should steal because it's better for you
+    // robin hood: handle a spot that you should steal because it's better for you
     fn steal(self, entry: VacantEntry<'a, K, V>) -> Self::Output;
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1737,12 +1737,15 @@ struct MakeEntry;
 
 impl<'a, Sz: Size, K: 'a, V: 'a> ProbeAction<'a, Sz, K, V> for MakeEntry {
     type Output = Entry<'a, K, V>;
+
     fn hit(self, entry: OccupiedEntry<'a, K, V>) -> Self::Output {
         Entry::Occupied(entry)
     }
+
     fn empty(self, entry: VacantEntry<'a, K, V>) -> Self::Output {
         Entry::Vacant(entry)
     }
+
     fn steal(self, entry: VacantEntry<'a, K, V>) -> Self::Output {
         Entry::Vacant(entry)
     }


### PR DESCRIPTION
This will close #108 

This doesn't so much improve the entry code rather than abstract away `entry` and `insert` into a `ProbeAction`. This forces monomorphization to give us the insert fast path that doesn't require the additional indirection that entry does.

It also implements `insert_full` on that fast path (`insert` is now just a call to `insert_full`), so that should be much faster as well, since it was formerly implemented in terms of `entry`.

Benchmarks
```
 name                                   control ns/iter  variable ns/iter  diff ns/iter  diff %  speedup 
 insert_orderedmap_100_000              2,688,143        2,616,739              -71,404  -2.66%   x 1.03 
 insert_orderedmap_10_000               275,198          272,283                 -2,915  -1.06%   x 1.01 
 insert_orderedmap_150                  4,116            3,862                     -254  -6.17%   x 1.07 
 insert_orderedmap_int_bigvalue_10_000  409,681          395,290                -14,391  -3.51%   x 1.04 
 insert_orderedmap_str_10_000           298,722          294,373                 -4,349  -1.46%   x 1.01 
 insert_orderedmap_string_10_000        2,027,784        1,948,038              -79,746  -3.93%   x 1.04 
```