### PR TITLE
Adding `reverse()` to `IndexMap` & `IndexSet`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1253,6 +1253,13 @@ where
         self.into_iter()
     }
 
+    /// Reverses the order of the map’s key-value pairs in place.
+    ///
+    /// Computes in **O(n)** time and **O(1)** space.
+    pub fn reverse(&mut self) {
+        self.core.reverse()
+    }
+
     /// Clears the `IndexMap`, returning all key-value pairs as a drain iterator.
     /// Keeps the allocated memory for reuse.
     pub fn drain(&mut self, range: RangeFull) -> Drain<K, V> {
@@ -1749,6 +1756,12 @@ impl<K, V> OrderMapCore<K, V> {
         let side_index = self.save_hash_index();
         self.entries
             .sort_by(move |ei, ej| compare(&ei.key, &ei.value, &ej.key, &ej.value));
+        self.restore_hash_index(side_index);
+    }
+
+    fn reverse(&mut self) {
+        let side_index = self.save_hash_index();
+        self.entries.reverse();
         self.restore_hash_index(side_index);
     }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1772,7 +1772,7 @@ impl<K, V> OrderMapCore<K, V> {
         {
             for pos in indices {
                 if let Some((i, _)) = pos.resolve::<Sz>() {
-                    pos.set_pos::<Sz>(len - i);
+                    pos.set_pos::<Sz>(len - i - 1);
                 }
             }
         }

--- a/src/set.rs
+++ b/src/set.rs
@@ -527,6 +527,13 @@ where
         }
     }
 
+    /// Reverses the order of the set’s values in place.
+    ///
+    /// Computes in **O(n)** time and **O(1)** space.
+    pub fn reverse(&mut self) {
+        self.map.reverse()
+    }
+
     /// Clears the `IndexSet`, returning all values as a drain iterator.
     /// Keeps the allocated memory for reuse.
     pub fn drain(&mut self, range: RangeFull) -> Drain<T> {


### PR DESCRIPTION
Closes #127.

Here's my work so far, just basing it off of what's done in `sort_by()`. Happy to include the more efficient re-indexing as you suggested, @cuviper! Just need to learn how.