### PR TITLE
Build serde without default features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,10 @@ script:
       if [ -z "$SKIP_TEST" ]; then
         cargo test --verbose --features "$FEATURES" &&
         cargo test --release --verbose --features "$FEATURES"
+        if [ "$FEATURES" = "serde-1" ]; then
+          cargo test --verbose -p test-serde &&
+          cargo test --release --verbose -p test-serde
+        fi
       fi &&
       if [ -n "$TEST_BENCH" ]; then
         cargo test -v --benches --no-run --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bench = false
 [build-dependencies]
 autocfg = "1"
 [dependencies]
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false }
 rayon = { version = "1.0", optional = true }
 
 [dev-dependencies]
@@ -41,7 +41,6 @@ rand = {version = "0.7", features = ["small_rng"] }
 quickcheck = { version = "0.9", default-features = false }
 fnv = "1.0"
 lazy_static = "1.3"
-serde_test = "1.0.99"
 
 [features]
 # Serialization with serde 1.0
@@ -62,4 +61,4 @@ tag-name = "{{version}}"
 features = ["serde-1", "rayon"]
 
 [workspace]
-members = ["test-nostd"]
+members = ["test-nostd", "test-serde"]

--- a/test-nostd/Cargo.toml
+++ b/test-nostd/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-indexmap = { path = ".." }
+indexmap = { path = "..", features = ["serde-1"] }
 # no-std compatible hasher
 twox-hash = { version = "1.5", default-features = false }
 

--- a/test-serde/Cargo.toml
+++ b/test-serde/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test-serde"
+version = "0.1.0"
+authors = ["bluss"]
+publish = false
+edition = "2018"
+
+[dependencies]
+
+[dev-dependencies]
+fnv = "1.0"
+indexmap = { path = "..", features = ["serde-1"] }
+serde_test = "1.0.99"

--- a/test-serde/src/lib.rs
+++ b/test-serde/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "serde-1")]
+#![cfg(test)]
 
 #[macro_use]
 extern crate indexmap;


### PR DESCRIPTION
We don't actually need any std/alloc features of `serde`, but our
dev-dependency on `serde_test` was indirectly turning on its default
features. However, if we isolate that testing to a separate crate in the
workspace, Cargo will compute the enabled features separately. Now we
can actually enable the `serde-1` feature in `test-nostd` too!

Closes #109.