### PR TITLE
Add FnvIndexMap, FnvIndexSet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "indexmap"
-version = "1.4.0"
-authors = [
-"bluss",
-"Josh Stone <cuviper@gmail.com>"
-]
+version = "1.4.1"
+authors = ["bluss", "Josh Stone <cuviper@gmail.com>"]
 documentation = "https://docs.rs/indexmap/"
 repository = "https://github.com/bluss/indexmap"
 license = "Apache-2.0/MIT"
@@ -31,9 +28,11 @@ bench = false
 
 [build-dependencies]
 autocfg = "1"
+
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }
 rayon = { version = "1.0", optional = true }
+fnv = { version = "1.0", optional = true }
 
 [dev-dependencies]
 itertools = "0.8"
@@ -58,7 +57,7 @@ no-dev-version = true
 tag-name = "{{version}}"
 
 [package.metadata.docs.rs]
-features = ["serde-1", "rayon"]
+features = ["serde-1", "rayon", "fnv"]
 
 [workspace]
 members = ["test-nostd", "test-serde"]

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,10 @@ which is roughly:
 Recent Changes
 ==============
 
+- 1.4.1
+
+  - Add ``FnvIndexMap`` and ``FnvIndexSet``, using a default FNV hasher
+
 - 1.4.0
 
   - Add new method ``get_index_of`` by @Thermatrix in PR 115_ and 120_

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@
 #[cfg(not(has_std))]
 #[macro_use(vec)]
 extern crate alloc;
+#[cfg(feature = "fnv")]
+extern crate fnv;
 
 #[cfg(not(has_std))]
 pub(crate) mod std {
@@ -70,6 +72,8 @@ pub(crate) mod std {
 
 #[cfg(not(has_std))]
 use std::vec::Vec;
+#[cfg(feature = "fnv")]
+use fnv::FnvBuildHasher;
 
 #[macro_use]
 mod macros;
@@ -171,3 +175,11 @@ trait Entries {
     where
         F: FnOnce(&mut [Self::Entry]);
 }
+
+/// An `IndexMap` using a default FNV hasher.
+#[cfg(feature = "fnv")]
+pub type FnvHashMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
+
+/// An `IndexSet` using a default FNV hasher.
+#[cfg(feature = "fnv")]
+pub type FnvHashSet<T> = IndexSet<T, FnvBuildHasher>;


### PR DESCRIPTION
Add type aliases for versions of `IndexMap` and `IndexSet` using a default FNV hasher, analog to those in the `fnv` crate itself. This adds an optional dependency to the `fnv` crate.