### PR TITLE
Expand drain to accept any RangeBounds<usize>

### DIFF
--- a/src/map/core.rs
+++ b/src/map/core.rs
@@ -15,10 +15,10 @@ use crate::vec::{Drain, Vec};
 use core::cmp;
 use core::fmt;
 use core::mem::replace;
-use core::ops::RangeFull;
+use core::ops::RangeBounds;
 
 use crate::equivalent::Equivalent;
-use crate::util::enumerate;
+use crate::util::{enumerate, simplify_range};
 use crate::{Bucket, Entries, HashValue};
 
 /// Core of the map that does not depend on S
@@ -129,8 +129,12 @@ impl<K, V> IndexMapCore<K, V> {
         self.entries.clear();
     }
 
-    pub(crate) fn drain(&mut self, range: RangeFull) -> Drain<'_, Bucket<K, V>> {
-        self.indices.clear();
+    pub(crate) fn drain<R>(&mut self, range: R) -> Drain<'_, Bucket<K, V>>
+    where
+        R: RangeBounds<usize>,
+    {
+        let range = simplify_range(range, self.entries.len());
+        self.erase_indices(range.start, range.end);
         self.entries.drain(range)
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use core::iter::Enumerate;
+use core::ops::{Bound, Range, RangeBounds};
 
 pub(crate) fn third<A, B, C>(t: (A, B, C)) -> C {
     t.2
@@ -9,4 +10,30 @@ where
     I: IntoIterator,
 {
     iterable.into_iter().enumerate()
+}
+
+pub(crate) fn simplify_range<R>(range: R, len: usize) -> Range<usize>
+where
+    R: RangeBounds<usize>,
+{
+    let start = match range.start_bound() {
+        Bound::Unbounded => 0,
+        Bound::Included(&i) if i <= len => i,
+        Bound::Excluded(&i) if i < len => i + 1,
+        bound => panic!("range start {:?} should be <= length {}", bound, len),
+    };
+    let end = match range.end_bound() {
+        Bound::Unbounded => len,
+        Bound::Excluded(&i) if i <= len => i,
+        Bound::Included(&i) if i < len => i + 1,
+        bound => panic!("range end {:?} should be <= length {}", bound, len),
+    };
+    if start > end {
+        panic!(
+            "range start {:?} should be <= range end {:?}",
+            range.start_bound(),
+            range.end_bound()
+        );
+    }
+    start..end
 }


### PR DESCRIPTION
Rather than just `RangeFull`, this lets us accept any `Range*` type or
even arbitrary `Bound` pairs, matching the signature of `Vec::drain`.