### PR TITLE
Relax IntoParallelIterator for &'a mut IndexMap

### DIFF
--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -117,7 +117,6 @@ impl<'a, K, V, S> IntoParallelIterator for &'a mut IndexMap<K, V, S>
 where
     K: Sync + Send,
     V: Send,
-    S: BuildHasher,
 {
     type Item = (&'a K, &'a mut V);
     type Iter = ParIterMut<'a, K, V>;


### PR DESCRIPTION
This was missed in #141, where all the other iterators dropped `S: BuildHasher`.