### PR TITLE
Add a feature to explicitly enable "std"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
     - rust: stable
       env:
        - FEATURES='rayon'
+    - rust: stable
+      env:
+       - FEATURES='std'
     - rust: beta
     - rust: nightly
       env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ fxhash = "0.2.1"
 # Serialization with serde 1.0
 serde-1 = ["serde"]
 
+# Force the use of `std`, bypassing target detection.
+std = []
+
 # for testing only, of course
 test_low_transition_point = []
 test_debug = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indexmap"
 edition = "2018"
-version = "1.5.1"
+version = "1.5.2"
 authors = [
 "bluss",
 "Josh Stone <cuviper@gmail.com>"

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,14 @@ which is roughly:
 Recent Changes
 ==============
 
+- 1.5.2
+
+  - The new "std" feature will force the use of ``std`` for users that explicitly
+    want the default ``S = RandomState``, bypassing the autodetection added in 1.3.0,
+    by @cuviper in PR 145_.
+
+.. _145: https://github.com/bluss/indexmap/pull/145
+
 - 1.5.1
 
   - Values can now be indexed by their ``usize`` position by @cuviper in PR 132_.

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,8 @@
 fn main() {
-    let ac = autocfg::new();
-    ac.emit_sysroot_crate("std");
+    // If "std" is explicitly requested, don't bother probing the target for it.
+    match std::env::var_os("CARGO_FEATURE_STD") {
+        Some(_) => autocfg::emit("has_std"),
+        None => autocfg::new().emit_sysroot_crate("std"),
+    }
     autocfg::rerun_path("build.rs");
 }


### PR DESCRIPTION
If you know you need "std", e.g. relying on default `S = RandomState`,
then you can enable this feature to force it on, bypassing target
detection. This may help scenarios where `autocfg` fails detection, like
issue #144, but at the very least it will speed up the build script by
avoiding extra `rustc` invocations.