### PR TITLE
Parameterize the index type of maps and sets

### DIFF
--- a/examples/custom_index.rs
+++ b/examples/custom_index.rs
@@ -1,0 +1,64 @@
+use fxhash::FxBuildHasher;
+use indexmap::{IndexMap, IndexSet, Indexable};
+use std::ops::{Index, IndexMut};
+
+fn main() {
+    let map: FancyMap<i32, i32> = (-10..=10).map(|i| (i, i * i)).collect();
+    let set: FancySet<i32> = map.values().cloned().collect();
+
+    println!("map to squares: {:?}", map);
+    assert_eq!(map[&-10], map[&10]); // index by key
+    assert_eq!(map[FancyIndex(0)], map[FancyIndex(20)]); // index by position
+
+    println!("unique squares: {:?}", set);
+    assert_eq!(set[FancyIndex(0)], 100); // index by position
+    assert_eq!(set[FancyIndex(10)], 0); // index by position
+}
+
+/// A custom index newtype ensures it can't be confused with indexes for
+/// unrelated containers. This one is also smaller to reduce map memory,
+/// which also reduces the maximum capacity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FancyIndex(u16);
+
+pub type FancyMap<K, V> = IndexMap<K, V, FxBuildHasher, FancyIndex>;
+pub type FancySet<T> = IndexSet<T, FxBuildHasher, FancyIndex>;
+
+impl Indexable for FancyIndex {
+    fn try_from_usize(i: usize) -> Option<Self> {
+        if i <= usize::from(u16::max_value()) {
+            Some(FancyIndex(i as u16))
+        } else {
+            None
+        }
+    }
+
+    fn try_into_usize(self) -> Option<usize> {
+        Some(self.0.into())
+    }
+}
+
+// Unfortunately, `Index` and `IndexMut for IndexMap` are not automatically implemented for all
+// `Idx: Indexable`, because the compiler considers `Index<Idx>` could potentially overlap with
+// `Index<&Q>` for keys, since references are fundamental. Therefore, we have to implement indexing
+// with `FancyIndex` ourselves. `IndexSet` does already implement all `Index<Idx>` though.
+
+impl<K, V> Index<FancyIndex> for FancyMap<K, V> {
+    type Output = V;
+
+    fn index(&self, index: FancyIndex) -> &V {
+        let (_key, value) = self
+            .get_index(index)
+            .expect("IndexMap: index out of bounds");
+        value
+    }
+}
+
+impl<K, V> IndexMut<FancyIndex> for FancyMap<K, V> {
+    fn index_mut(&mut self, index: FancyIndex) -> &mut V {
+        let (_key, value) = self
+            .get_index_mut(index)
+            .expect("IndexMap: index out of bounds");
+        value
+    }
+}

--- a/examples/custom_index.rs
+++ b/examples/custom_index.rs
@@ -24,17 +24,19 @@ pub struct FancyIndex(u16);
 pub type FancyMap<K, V> = IndexMap<K, V, FxBuildHasher, FancyIndex>;
 pub type FancySet<T> = IndexSet<T, FxBuildHasher, FancyIndex>;
 
-impl Indexable for FancyIndex {
-    fn try_from_usize(i: usize) -> Option<Self> {
-        if i <= usize::from(u16::max_value()) {
-            Some(FancyIndex(i as u16))
-        } else {
-            None
-        }
-    }
+impl Indexable for FancyIndex {}
 
-    fn try_into_usize(self) -> Option<usize> {
-        Some(self.0.into())
+impl TryFrom<usize> for FancyIndex {
+    type Error = <u16 as TryFrom<usize>>::Error;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        Ok(FancyIndex(u16::try_from(value)?))
+    }
+}
+
+impl From<FancyIndex> for usize {
+    fn from(i: FancyIndex) -> usize {
+        i.0.into()
     }
 }
 

--- a/src/indexable.rs
+++ b/src/indexable.rs
@@ -1,0 +1,89 @@
+use crate::IndexMap;
+use core::ops::{Index, IndexMut};
+
+/// Indexable types can convert to and from `usize`.
+pub trait Indexable: Sized + Copy + Ord + Send + Sync {
+    /// Creates an index from a `usize` or returns `None`.
+    fn try_from_usize(i: usize) -> Option<Self>;
+
+    /// Creates an index from a `usize`; panics on failure.
+    #[inline]
+    fn from_usize(i: usize) -> Self {
+        Self::try_from_usize(i).expect("invalid index!")
+    }
+
+    /// Converts the index to a `usize` or returns `None`.
+    fn try_into_usize(self) -> Option<usize>;
+
+    /// Converts the index to a `usize`; panics on failure.
+    #[inline]
+    fn into_usize(self) -> usize {
+        self.try_into_usize().expect("invalid index!")
+    }
+}
+
+impl Indexable for usize {
+    #[inline]
+    fn try_from_usize(i: usize) -> Option<Self> {
+        Some(i)
+    }
+
+    #[inline]
+    fn from_usize(i: usize) -> Self {
+        i
+    }
+
+    #[inline]
+    fn try_into_usize(self) -> Option<usize> {
+        Some(self)
+    }
+
+    #[inline]
+    fn into_usize(self) -> usize {
+        self
+    }
+}
+
+macro_rules! impl_indexable {
+    ($($ty:ident)*) => {$(
+        impl Indexable for $ty {
+            #[inline]
+            fn try_from_usize(i: usize) -> Option<Self> {
+                if i <= core::$ty::MAX as usize {
+                    Some(i as $ty)
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn try_into_usize(self) -> Option<usize> {
+                if self <= core::usize::MAX as $ty {
+                    Some(self as usize)
+                } else {
+                    None
+                }
+            }
+        }
+
+        impl<K, V, S> Index<$ty> for IndexMap<K, V, S, $ty> {
+            type Output = V;
+
+            fn index(&self, index: $ty) -> &V {
+                self.get_index(index)
+                    .expect("IndexMap: index out of bounds")
+                    .1
+            }
+        }
+
+        impl<K, V, S> IndexMut<$ty> for IndexMap<K, V, S, $ty> {
+            fn index_mut(&mut self, index: $ty) -> &mut V {
+                self.get_index_mut(index)
+                    .expect("IndexMap: index out of bounds")
+                    .1
+            }
+        }
+    )*}
+}
+
+impl_indexable!(u8 u16 u32 u64 u128);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ use alloc::vec::{self, Vec};
 #[macro_use]
 mod macros;
 mod equivalent;
+mod indexable;
 mod mutable_keys;
 #[cfg(feature = "serde")]
 mod serde;
@@ -106,6 +107,7 @@ mod rayon;
 mod rustc;
 
 pub use crate::equivalent::Equivalent;
+pub use crate::indexable::Indexable;
 pub use crate::map::IndexMap;
 pub use crate::set::IndexSet;
 
@@ -181,11 +183,16 @@ impl<K, V> Bucket<K, V> {
     }
 }
 
+/// Get basic unbounded access to entries
 trait Entries {
     type Entry;
     fn into_entries(self) -> Vec<Self::Entry>;
     fn as_entries(&self) -> &[Self::Entry];
     fn as_entries_mut(&mut self) -> &mut [Self::Entry];
+}
+
+/// Borrow entries and fix the indices afterward
+trait WithEntries: Entries {
     fn with_entries<F>(&mut self, f: F)
     where
         F: FnOnce(&mut [Self::Entry]);

--- a/src/map.rs
+++ b/src/map.rs
@@ -772,7 +772,10 @@ impl<K, V, S, Idx: Indexable> IndexMap<K, V, S, Idx> {
     ///
     /// Computes in **O(1)** time.
     pub fn get_index(&self, index: Idx) -> Option<(&K, &V)> {
-        self.as_entries().get(index.into_usize()).map(Bucket::refs)
+        if let Ok(index_usize) = index.try_into() {
+            return self.as_entries().get(index_usize).map(Bucket::refs);
+        }
+        None
     }
 
     /// Get a key-value pair by index
@@ -781,9 +784,13 @@ impl<K, V, S, Idx: Indexable> IndexMap<K, V, S, Idx> {
     ///
     /// Computes in **O(1)** time.
     pub fn get_index_mut(&mut self, index: Idx) -> Option<(&K, &mut V)> {
-        self.as_entries_mut()
-            .get_mut(index.into_usize())
-            .map(Bucket::ref_mut)
+        if let Ok(index_usize) = index.try_into() {
+            return self
+                .as_entries_mut()
+                .get_mut(index_usize)
+                .map(Bucket::ref_mut);
+        }
+        None
     }
 
     /// Get the first key-value pair

--- a/src/map.rs
+++ b/src/map.rs
@@ -21,8 +21,9 @@ use std::collections::hash_map::RandomState;
 
 use self::core::IndexMapCore;
 use crate::equivalent::Equivalent;
+use crate::indexable::Indexable;
 use crate::util::third;
-use crate::{Bucket, Entries, HashValue};
+use crate::{Bucket, Entries, HashValue, WithEntries};
 
 pub use self::core::{Entry, OccupiedEntry, VacantEntry};
 
@@ -68,21 +69,22 @@ pub use self::core::{Entry, OccupiedEntry, VacantEntry};
 /// assert_eq!(letters.get(&'y'), None);
 /// ```
 #[cfg(feature = "std")]
-pub struct IndexMap<K, V, S = RandomState> {
-    pub(crate) core: IndexMapCore<K, V>,
+pub struct IndexMap<K, V, S = RandomState, Idx = usize> {
+    pub(crate) core: IndexMapCore<K, V, Idx>,
     hash_builder: S,
 }
 #[cfg(not(feature = "std"))]
-pub struct IndexMap<K, V, S> {
-    pub(crate) core: IndexMapCore<K, V>,
+pub struct IndexMap<K, V, S, Idx = usize> {
+    pub(crate) core: IndexMapCore<K, V, Idx>,
     hash_builder: S,
 }
 
-impl<K, V, S> Clone for IndexMap<K, V, S>
+impl<K, V, S, Idx> Clone for IndexMap<K, V, S, Idx>
 where
     K: Clone,
     V: Clone,
     S: Clone,
+    Idx: Indexable,
 {
     fn clone(&self) -> Self {
         IndexMap {
@@ -97,7 +99,7 @@ where
     }
 }
 
-impl<K, V, S> Entries for IndexMap<K, V, S> {
+impl<K, V, S, Idx> Entries for IndexMap<K, V, S, Idx> {
     type Entry = Bucket<K, V>;
 
     #[inline]
@@ -114,7 +116,9 @@ impl<K, V, S> Entries for IndexMap<K, V, S> {
     fn as_entries_mut(&mut self) -> &mut [Self::Entry] {
         self.core.as_entries_mut()
     }
+}
 
+impl<K, V, S, Idx: Indexable> WithEntries for IndexMap<K, V, S, Idx> {
     fn with_entries<F>(&mut self, f: F)
     where
         F: FnOnce(&mut [Self::Entry]),
@@ -123,10 +127,11 @@ impl<K, V, S> Entries for IndexMap<K, V, S> {
     }
 }
 
-impl<K, V, S> fmt::Debug for IndexMap<K, V, S>
+impl<K, V, S, Idx> fmt::Debug for IndexMap<K, V, S, Idx>
 where
     K: fmt::Debug,
     V: fmt::Debug,
+    Idx: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if cfg!(not(feature = "test_debug")) {
@@ -158,7 +163,7 @@ impl<K, V> IndexMap<K, V> {
     }
 }
 
-impl<K, V, S> IndexMap<K, V, S> {
+impl<K, V, S, Idx> IndexMap<K, V, S, Idx> {
     /// Create a new map with capacity for `n` key-value pairs. (Does not
     /// allocate if `n` is zero.)
     ///
@@ -268,7 +273,9 @@ impl<K, V, S> IndexMap<K, V, S> {
     pub fn clear(&mut self) {
         self.core.clear();
     }
+}
 
+impl<K, V, S, Idx: Indexable> IndexMap<K, V, S, Idx> {
     /// Shortens the map, keeping the first `len` elements and dropping the rest.
     ///
     /// If `len` is greater than the map's current length, this has no effect.
@@ -279,7 +286,7 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// Clears the `IndexMap` in the given index range, returning those
     /// key-value pairs as a drain iterator.
     ///
-    /// The range may be any type that implements `RangeBounds<usize>`,
+    /// The range may be any type that implements `RangeBounds<Idx>`,
     /// including all of the `std::ops::Range*` types, or even a tuple pair of
     /// `Bound` start and end values. To drain the map entirely, use `RangeFull`
     /// like `map.drain(..)`.
@@ -291,7 +298,7 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// the end point is greater than the length of the map.
     pub fn drain<R>(&mut self, range: R) -> Drain<'_, K, V>
     where
-        R: RangeBounds<usize>,
+        R: RangeBounds<Idx>,
     {
         Drain {
             iter: self.core.drain(range),
@@ -305,7 +312,7 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// the elements `[0, at)` with its previous capacity unchanged.
     ///
     /// ***Panics*** if `at > len`.
-    pub fn split_off(&mut self, at: usize) -> Self
+    pub fn split_off(&mut self, at: Idx) -> Self
     where
         S: Clone,
     {
@@ -316,10 +323,11 @@ impl<K, V, S> IndexMap<K, V, S> {
     }
 }
 
-impl<K, V, S> IndexMap<K, V, S>
+impl<K, V, S, Idx> IndexMap<K, V, S, Idx>
 where
     K: Hash + Eq,
     S: BuildHasher,
+    Idx: Indexable,
 {
     /// Reserve capacity for `additional` more key-value pairs.
     ///
@@ -378,7 +386,7 @@ where
     ///
     /// See also [`entry`](#method.entry) if you you want to insert *or* modify
     /// or if you need to get the index of the corresponding key-value pair.
-    pub fn insert_full(&mut self, key: K, value: V) -> (usize, Option<V>) {
+    pub fn insert_full(&mut self, key: K, value: V) -> (Idx, Option<V>) {
         let hash = self.hash(&key);
         self.core.insert_full(hash, key, value)
     }
@@ -387,7 +395,7 @@ where
     /// in-place manipulation.
     ///
     /// Computes in **O(1)** time (amortized average).
-    pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
+    pub fn entry(&mut self, key: K) -> Entry<'_, K, V, Idx> {
         let hash = self.hash(&key);
         self.core.entry(hash, key)
     }
@@ -411,7 +419,7 @@ where
         Q: Hash + Equivalent<K>,
     {
         if let Some(i) = self.get_index_of(key) {
-            let entry = &self.as_entries()[i];
+            let entry = &self.as_entries()[i.into_usize()];
             Some(&entry.value)
         } else {
             None
@@ -427,7 +435,7 @@ where
         Q: Hash + Equivalent<K>,
     {
         if let Some(i) = self.get_index_of(key) {
-            let entry = &self.as_entries()[i];
+            let entry = &self.as_entries()[i.into_usize()];
             Some((&entry.key, &entry.value))
         } else {
             None
@@ -435,12 +443,12 @@ where
     }
 
     /// Return item index, key and value
-    pub fn get_full<Q: ?Sized>(&self, key: &Q) -> Option<(usize, &K, &V)>
+    pub fn get_full<Q: ?Sized>(&self, key: &Q) -> Option<(Idx, &K, &V)>
     where
         Q: Hash + Equivalent<K>,
     {
         if let Some(i) = self.get_index_of(key) {
-            let entry = &self.as_entries()[i];
+            let entry = &self.as_entries()[i.into_usize()];
             Some((i, &entry.key, &entry.value))
         } else {
             None
@@ -450,7 +458,7 @@ where
     /// Return item index, if it exists in the map
     ///
     /// Computes in **O(1)** time (average).
-    pub fn get_index_of<Q: ?Sized>(&self, key: &Q) -> Option<usize>
+    pub fn get_index_of<Q: ?Sized>(&self, key: &Q) -> Option<Idx>
     where
         Q: Hash + Equivalent<K>,
     {
@@ -467,19 +475,19 @@ where
         Q: Hash + Equivalent<K>,
     {
         if let Some(i) = self.get_index_of(key) {
-            let entry = &mut self.as_entries_mut()[i];
+            let entry = &mut self.as_entries_mut()[i.into_usize()];
             Some(&mut entry.value)
         } else {
             None
         }
     }
 
-    pub fn get_full_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<(usize, &K, &mut V)>
+    pub fn get_full_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<(Idx, &K, &mut V)>
     where
         Q: Hash + Equivalent<K>,
     {
         if let Some(i) = self.get_index_of(key) {
-            let entry = &mut self.as_entries_mut()[i];
+            let entry = &mut self.as_entries_mut()[i.into_usize()];
             Some((i, &entry.key, &mut entry.value))
         } else {
             None
@@ -561,7 +569,7 @@ where
     /// Return `None` if `key` is not in map.
     ///
     /// Computes in **O(1)** time (average).
-    pub fn swap_remove_full<Q: ?Sized>(&mut self, key: &Q) -> Option<(usize, K, V)>
+    pub fn swap_remove_full<Q: ?Sized>(&mut self, key: &Q) -> Option<(Idx, K, V)>
     where
         Q: Hash + Equivalent<K>,
     {
@@ -618,7 +626,7 @@ where
     /// Return `None` if `key` is not in map.
     ///
     /// Computes in **O(n)** time (average).
-    pub fn shift_remove_full<Q: ?Sized>(&mut self, key: &Q) -> Option<(usize, K, V)>
+    pub fn shift_remove_full<Q: ?Sized>(&mut self, key: &Q) -> Option<(Idx, K, V)>
     where
         Q: Hash + Equivalent<K>,
     {
@@ -757,14 +765,14 @@ where
     }
 }
 
-impl<K, V, S> IndexMap<K, V, S> {
+impl<K, V, S, Idx: Indexable> IndexMap<K, V, S, Idx> {
     /// Get a key-value pair by index
     ///
     /// Valid indices are *0 <= index < self.len()*
     ///
     /// Computes in **O(1)** time.
-    pub fn get_index(&self, index: usize) -> Option<(&K, &V)> {
-        self.as_entries().get(index).map(Bucket::refs)
+    pub fn get_index(&self, index: Idx) -> Option<(&K, &V)> {
+        self.as_entries().get(index.into_usize()).map(Bucket::refs)
     }
 
     /// Get a key-value pair by index
@@ -772,8 +780,10 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// Valid indices are *0 <= index < self.len()*
     ///
     /// Computes in **O(1)** time.
-    pub fn get_index_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
-        self.as_entries_mut().get_mut(index).map(Bucket::ref_mut)
+    pub fn get_index_mut(&mut self, index: Idx) -> Option<(&K, &mut V)> {
+        self.as_entries_mut()
+            .get_mut(index.into_usize())
+            .map(Bucket::ref_mut)
     }
 
     /// Get the first key-value pair
@@ -813,7 +823,7 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// the position of what used to be the last element!**
     ///
     /// Computes in **O(1)** time (average).
-    pub fn swap_remove_index(&mut self, index: usize) -> Option<(K, V)> {
+    pub fn swap_remove_index(&mut self, index: Idx) -> Option<(K, V)> {
         self.core.swap_remove_index(index)
     }
 
@@ -826,14 +836,14 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// **This perturbs the index of all of those elements!**
     ///
     /// Computes in **O(n)** time (average).
-    pub fn shift_remove_index(&mut self, index: usize) -> Option<(K, V)> {
+    pub fn shift_remove_index(&mut self, index: Idx) -> Option<(K, V)> {
         self.core.shift_remove_index(index)
     }
 
     /// Swaps the position of two key-value pairs in the map.
     ///
     /// ***Panics*** if `a` or `b` are out of bounds.
-    pub fn swap_indices(&mut self, a: usize, b: usize) {
+    pub fn swap_indices(&mut self, a: Idx, b: Idx) {
         self.core.swap_indices(a, b)
     }
 }
@@ -1186,7 +1196,7 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Drain<'_, K, V> {
     }
 }
 
-impl<'a, K, V, S> IntoIterator for &'a IndexMap<K, V, S> {
+impl<'a, K, V, S, Idx> IntoIterator for &'a IndexMap<K, V, S, Idx> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
     fn into_iter(self) -> Self::IntoIter {
@@ -1194,7 +1204,7 @@ impl<'a, K, V, S> IntoIterator for &'a IndexMap<K, V, S> {
     }
 }
 
-impl<'a, K, V, S> IntoIterator for &'a mut IndexMap<K, V, S> {
+impl<'a, K, V, S, Idx> IntoIterator for &'a mut IndexMap<K, V, S, Idx> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
     fn into_iter(self) -> Self::IntoIter {
@@ -1202,7 +1212,7 @@ impl<'a, K, V, S> IntoIterator for &'a mut IndexMap<K, V, S> {
     }
 }
 
-impl<K, V, S> IntoIterator for IndexMap<K, V, S> {
+impl<K, V, S, Idx> IntoIterator for IndexMap<K, V, S, Idx> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
     fn into_iter(self) -> Self::IntoIter {
@@ -1234,11 +1244,12 @@ impl<K, V, S> IntoIterator for IndexMap<K, V, S> {
 /// map.insert("foo", 1);
 /// println!("{:?}", map["bar"]); // panics!
 /// ```
-impl<K, V, Q: ?Sized, S> Index<&Q> for IndexMap<K, V, S>
+impl<K, V, Q, S, Idx> Index<&Q> for IndexMap<K, V, S, Idx>
 where
-    Q: Hash + Equivalent<K>,
+    Q: ?Sized + Hash + Equivalent<K>,
     K: Hash + Eq,
     S: BuildHasher,
+    Idx: Indexable,
 {
     type Output = V;
 
@@ -1279,11 +1290,12 @@ where
 /// map.insert("foo", 1);
 /// map["bar"] = 1; // panics!
 /// ```
-impl<K, V, Q: ?Sized, S> IndexMut<&Q> for IndexMap<K, V, S>
+impl<K, V, Q, S, Idx> IndexMut<&Q> for IndexMap<K, V, S, Idx>
 where
-    Q: Hash + Equivalent<K>,
+    Q: ?Sized + Hash + Equivalent<K>,
     K: Hash + Eq,
     S: BuildHasher,
+    Idx: Indexable,
 {
     /// Returns a mutable reference to the value corresponding to the supplied `key`.
     ///
@@ -1321,7 +1333,16 @@ where
 /// map.insert("foo", 1);
 /// println!("{:?}", map[10]); // panics!
 /// ```
-impl<K, V, S> Index<usize> for IndexMap<K, V, S> {
+///
+/// # Implementation note
+///
+/// Unfortunately, this can't be implemented for arbitrary `Idx: Indexable`,
+/// because a blanket `Index<Idx>` would overlap with `Index<&Q>` by key. So in
+/// addition to this primary implementation, there are implementations for all
+/// primitive unsigned integers: `Index<u32> for IndexMap<K, V, S, u32>`, etc.
+///
+/// As a downstream crate author, you may implement your own `Index<NewIndex>`.
+impl<K, V, S> Index<usize> for IndexMap<K, V, S, usize> {
     type Output = V;
 
     /// Returns a reference to the value at the supplied `index`.
@@ -1363,7 +1384,17 @@ impl<K, V, S> Index<usize> for IndexMap<K, V, S> {
 /// map.insert("foo", 1);
 /// map[10] = 1; // panics!
 /// ```
-impl<K, V, S> IndexMut<usize> for IndexMap<K, V, S> {
+///
+/// # Implementation note
+///
+/// Unfortunately, this can't be implemented for arbitrary `Idx: Indexable`,
+/// because a blanket `IndexMut<Idx>` would overlap with `IndexMut<&Q>` by key.
+/// So in addition to this primary implementation, there are implementations for
+/// all primitive unsigned integers:
+/// `IndexMut<u32> for IndexMap<K, V, S, u32>`, etc.
+///
+/// As a downstream crate author, you may implement your own `IndexMut<NewIndex>`.
+impl<K, V, S> IndexMut<usize> for IndexMap<K, V, S, usize> {
     /// Returns a mutable reference to the value at the supplied `index`.
     ///
     /// ***Panics*** if `index` is out of bounds.
@@ -1374,10 +1405,11 @@ impl<K, V, S> IndexMut<usize> for IndexMap<K, V, S> {
     }
 }
 
-impl<K, V, S> FromIterator<(K, V)> for IndexMap<K, V, S>
+impl<K, V, S, Idx> FromIterator<(K, V)> for IndexMap<K, V, S, Idx>
 where
     K: Hash + Eq,
     S: BuildHasher + Default,
+    Idx: Indexable,
 {
     /// Create an `IndexMap` from the sequence of key-value pairs in the
     /// iterable.
@@ -1394,7 +1426,7 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<K, V, const N: usize> From<[(K, V); N]> for IndexMap<K, V, RandomState>
+impl<K, V, const N: usize> From<[(K, V); N]> for IndexMap<K, V, RandomState, usize>
 where
     K: Hash + Eq,
 {
@@ -1412,10 +1444,11 @@ where
     }
 }
 
-impl<K, V, S> Extend<(K, V)> for IndexMap<K, V, S>
+impl<K, V, S, Idx> Extend<(K, V)> for IndexMap<K, V, S, Idx>
 where
     K: Hash + Eq,
     S: BuildHasher,
+    Idx: Indexable,
 {
     /// Extend the map with all key-value pairs in the iterable.
     ///
@@ -1445,11 +1478,12 @@ where
     }
 }
 
-impl<'a, K, V, S> Extend<(&'a K, &'a V)> for IndexMap<K, V, S>
+impl<'a, K, V, S, Idx> Extend<(&'a K, &'a V)> for IndexMap<K, V, S, Idx>
 where
     K: Hash + Eq + Copy,
     V: Copy,
     S: BuildHasher,
+    Idx: Indexable,
 {
     /// Extend the map with all key-value pairs in the iterable.
     ///
@@ -1459,7 +1493,7 @@ where
     }
 }
 
-impl<K, V, S> Default for IndexMap<K, V, S>
+impl<K, V, S, Idx> Default for IndexMap<K, V, S, Idx>
 where
     S: Default,
 {
@@ -1469,14 +1503,15 @@ where
     }
 }
 
-impl<K, V1, S1, V2, S2> PartialEq<IndexMap<K, V2, S2>> for IndexMap<K, V1, S1>
+impl<K, V1, S1, V2, S2, Idx> PartialEq<IndexMap<K, V2, S2, Idx>> for IndexMap<K, V1, S1, Idx>
 where
     K: Hash + Eq,
     V1: PartialEq<V2>,
     S1: BuildHasher,
     S2: BuildHasher,
+    Idx: Indexable,
 {
-    fn eq(&self, other: &IndexMap<K, V2, S2>) -> bool {
+    fn eq(&self, other: &IndexMap<K, V2, S2, Idx>) -> bool {
         if self.len() != other.len() {
             return false;
         }
@@ -1486,11 +1521,12 @@ where
     }
 }
 
-impl<K, V, S> Eq for IndexMap<K, V, S>
+impl<K, V, S, Idx> Eq for IndexMap<K, V, S, Idx>
 where
     K: Eq + Hash,
     V: Eq,
     S: BuildHasher,
+    Idx: Indexable,
 {
 }
 

--- a/src/map/core.rs
+++ b/src/map/core.rs
@@ -281,13 +281,13 @@ impl<K, V, Idx: Indexable> IndexMapCore<K, V, Idx> {
 
     /// Remove an entry by shifting all entries that follow it
     pub(crate) fn shift_remove_index(&mut self, index: Idx) -> Option<(K, V)> {
-        match self.entries.get(index.into_usize()) {
-            Some(entry) => {
+        if let Ok(index_usize) = index.try_into() {
+            if let Some(entry) = self.entries.get(index_usize) {
                 erase_index(&mut self.indices, entry.hash, index);
-                Some(self.shift_remove_finish(index))
+                return Some(self.shift_remove_finish(index));
             }
-            None => None,
         }
+        None
     }
 
     /// Remove an entry by shifting all entries that follow it
@@ -339,13 +339,13 @@ impl<K, V, Idx: Indexable> IndexMapCore<K, V, Idx> {
 
     /// Remove an entry by swapping it with the last
     pub(crate) fn swap_remove_index(&mut self, index: Idx) -> Option<(K, V)> {
-        match self.entries.get(index.into_usize()) {
-            Some(entry) => {
+        if let Ok(index_usize) = index.try_into() {
+            if let Some(entry) = self.entries.get(index_usize) {
                 erase_index(&mut self.indices, entry.hash, index);
-                Some(self.swap_remove_finish(index))
+                return Some(self.swap_remove_finish(index));
             }
-            None => None,
         }
+        None
     }
 
     /// Finish removing an entry by swapping it with the last

--- a/src/mutable_keys.rs
+++ b/src/mutable_keys.rs
@@ -35,7 +35,7 @@ pub trait MutableKeys<Idx = usize>: private::Sealed {
     /// Valid indices are *0 <= index < self.len()*
     ///
     /// Computes in **O(1)** time.
-    fn get_index_mut2(&mut self, index: usize) -> Option<(&mut Self::Key, &mut Self::Value)>;
+    fn get_index_mut2(&mut self, index: Idx) -> Option<(&mut Self::Key, &mut Self::Value)>;
 
     /// Scan through each key-value pair in the map and keep those where the
     /// closure `keep` returns `true`.
@@ -73,8 +73,10 @@ where
         }
     }
 
-    fn get_index_mut2(&mut self, index: usize) -> Option<(&mut K, &mut V)> {
-        self.as_entries_mut().get_mut(index).map(Bucket::muts)
+    fn get_index_mut2(&mut self, index: Idx) -> Option<(&mut K, &mut V)> {
+        self.as_entries_mut()
+            .get_mut(index.into_usize())
+            .map(Bucket::muts)
     }
 
     fn retain2<F>(&mut self, keep: F)

--- a/src/mutable_keys.rs
+++ b/src/mutable_keys.rs
@@ -74,9 +74,10 @@ where
     }
 
     fn get_index_mut2(&mut self, index: Idx) -> Option<(&mut K, &mut V)> {
-        self.as_entries_mut()
-            .get_mut(index.into_usize())
-            .map(Bucket::muts)
+        if let Ok(index_usize) = index.try_into() {
+            return self.as_entries_mut().get_mut(index_usize).map(Bucket::muts);
+        }
+        None
     }
 
     fn retain2<F>(&mut self, keep: F)

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -18,9 +18,11 @@ use core::ops::RangeBounds;
 use crate::Bucket;
 use crate::Entries;
 use crate::IndexMap;
+use crate::Indexable;
+use crate::WithEntries;
 
 /// Requires crate feature `"rayon"`.
-impl<K, V, S> IntoParallelIterator for IndexMap<K, V, S>
+impl<K, V, S, Idx> IntoParallelIterator for IndexMap<K, V, S, Idx>
 where
     K: Send,
     V: Send,
@@ -64,7 +66,7 @@ impl<K: Send, V: Send> IndexedParallelIterator for IntoParIter<K, V> {
 }
 
 /// Requires crate feature `"rayon"`.
-impl<'a, K, V, S> IntoParallelIterator for &'a IndexMap<K, V, S>
+impl<'a, K, V, S, Idx> IntoParallelIterator for &'a IndexMap<K, V, S, Idx>
 where
     K: Sync,
     V: Sync,
@@ -114,7 +116,7 @@ impl<K: Sync, V: Sync> IndexedParallelIterator for ParIter<'_, K, V> {
 }
 
 /// Requires crate feature `"rayon"`.
-impl<'a, K, V, S> IntoParallelIterator for &'a mut IndexMap<K, V, S>
+impl<'a, K, V, S, Idx> IntoParallelIterator for &'a mut IndexMap<K, V, S, Idx>
 where
     K: Sync + Send,
     V: Send,
@@ -158,15 +160,16 @@ impl<K: Sync + Send, V: Send> IndexedParallelIterator for ParIterMut<'_, K, V> {
 }
 
 /// Requires crate feature `"rayon"`.
-impl<'a, K, V, S> ParallelDrainRange<usize> for &'a mut IndexMap<K, V, S>
+impl<'a, K, V, S, Idx> ParallelDrainRange<Idx> for &'a mut IndexMap<K, V, S, Idx>
 where
     K: Send,
     V: Send,
+    Idx: Indexable,
 {
     type Item = (K, V);
     type Iter = ParDrain<'a, K, V>;
 
-    fn par_drain<R: RangeBounds<usize>>(self, range: R) -> Self::Iter {
+    fn par_drain<R: RangeBounds<Idx>>(self, range: R) -> Self::Iter {
         ParDrain {
             entries: self.core.par_drain(range),
         }
@@ -199,7 +202,7 @@ impl<K: Send, V: Send> IndexedParallelIterator for ParDrain<'_, K, V> {
 /// The following methods **require crate feature `"rayon"`**.
 ///
 /// See also the `IntoParallelIterator` implementations.
-impl<K, V, S> IndexMap<K, V, S>
+impl<K, V, S, Idx> IndexMap<K, V, S, Idx>
 where
     K: Sync,
     V: Sync,
@@ -225,15 +228,16 @@ where
     }
 }
 
-impl<K, V, S> IndexMap<K, V, S>
+impl<K, V, S, Idx> IndexMap<K, V, S, Idx>
 where
     K: Hash + Eq + Sync,
     V: Sync,
     S: BuildHasher,
+    Idx: Indexable,
 {
     /// Returns `true` if `self` contains all of the same key-value pairs as `other`,
     /// regardless of each map's indexed order, determined in parallel.
-    pub fn par_eq<V2, S2>(&self, other: &IndexMap<K, V2, S2>) -> bool
+    pub fn par_eq<V2, S2>(&self, other: &IndexMap<K, V2, S2, Idx>) -> bool
     where
         V: PartialEq<V2>,
         V2: Sync,
@@ -315,7 +319,7 @@ impl<K: Sync, V: Sync> IndexedParallelIterator for ParValues<'_, K, V> {
 }
 
 /// Requires crate feature `"rayon"`.
-impl<K, V, S> IndexMap<K, V, S>
+impl<K, V, S, Idx> IndexMap<K, V, S, Idx>
 where
     K: Send,
     V: Send,
@@ -331,11 +335,12 @@ where
     }
 }
 
-impl<K, V, S> IndexMap<K, V, S>
+impl<K, V, S, Idx> IndexMap<K, V, S, Idx>
 where
     K: Hash + Eq + Send,
     V: Send,
     S: BuildHasher,
+    Idx: Indexable,
 {
     /// Sort the map’s key-value pairs in parallel, by the default ordering of the keys.
     pub fn par_sort_keys(&mut self)
@@ -437,11 +442,12 @@ impl<K: Send, V: Send> IndexedParallelIterator for ParValuesMut<'_, K, V> {
 }
 
 /// Requires crate feature `"rayon"`.
-impl<K, V, S> FromParallelIterator<(K, V)> for IndexMap<K, V, S>
+impl<K, V, S, Idx> FromParallelIterator<(K, V)> for IndexMap<K, V, S, Idx>
 where
     K: Eq + Hash + Send,
     V: Send,
     S: BuildHasher + Default + Send,
+    Idx: Indexable,
 {
     fn from_par_iter<I>(iter: I) -> Self
     where
@@ -458,11 +464,12 @@ where
 }
 
 /// Requires crate feature `"rayon"`.
-impl<K, V, S> ParallelExtend<(K, V)> for IndexMap<K, V, S>
+impl<K, V, S, Idx> ParallelExtend<(K, V)> for IndexMap<K, V, S, Idx>
 where
     K: Eq + Hash + Send,
     V: Send,
     S: BuildHasher + Send,
+    Idx: Indexable,
 {
     fn par_extend<I>(&mut self, iter: I)
     where
@@ -475,11 +482,12 @@ where
 }
 
 /// Requires crate feature `"rayon"`.
-impl<'a, K: 'a, V: 'a, S> ParallelExtend<(&'a K, &'a V)> for IndexMap<K, V, S>
+impl<'a, K: 'a, V: 'a, S, Idx> ParallelExtend<(&'a K, &'a V)> for IndexMap<K, V, S, Idx>
 where
     K: Copy + Eq + Hash + Send + Sync,
     V: Copy + Send + Sync,
     S: BuildHasher + Send,
+    Idx: Indexable,
 {
     fn par_extend<I>(&mut self, iter: I)
     where

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -9,7 +9,7 @@ use rustc_rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelI
 mod map {
     use super::*;
 
-    impl<K, V, S> IntoParallelIterator for IndexMap<K, V, S>
+    impl<K, V, S, Idx> IntoParallelIterator for IndexMap<K, V, S, Idx>
     where
         K: Send,
         V: Send,
@@ -38,7 +38,7 @@ mod map {
         indexed_parallel_iterator_methods!(Bucket::key_value);
     }
 
-    impl<'a, K, V, S> IntoParallelIterator for &'a IndexMap<K, V, S>
+    impl<'a, K, V, S, Idx> IntoParallelIterator for &'a IndexMap<K, V, S, Idx>
     where
         K: Sync,
         V: Sync,
@@ -67,7 +67,7 @@ mod map {
         indexed_parallel_iterator_methods!(Bucket::refs);
     }
 
-    impl<'a, K, V, S> IntoParallelIterator for &'a mut IndexMap<K, V, S>
+    impl<'a, K, V, S, Idx> IntoParallelIterator for &'a mut IndexMap<K, V, S, Idx>
     where
         K: Sync + Send,
         V: Send,
@@ -100,7 +100,7 @@ mod map {
 mod set {
     use super::*;
 
-    impl<T, S> IntoParallelIterator for IndexSet<T, S>
+    impl<T, S, Idx> IntoParallelIterator for IndexSet<T, S, Idx>
     where
         T: Send,
     {
@@ -128,7 +128,7 @@ mod set {
         indexed_parallel_iterator_methods!(Bucket::key);
     }
 
-    impl<'a, T, S> IntoParallelIterator for &'a IndexSet<T, S>
+    impl<'a, T, S, Idx> IntoParallelIterator for &'a IndexSet<T, S, Idx>
     where
         T: Sync,
     {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -9,13 +9,15 @@ use core::hash::{BuildHasher, Hash};
 use core::marker::PhantomData;
 
 use crate::IndexMap;
+use crate::Indexable;
 
 /// Requires crate feature `"serde"`
-impl<K, V, S> Serialize for IndexMap<K, V, S>
+impl<K, V, S, Idx> Serialize for IndexMap<K, V, S, Idx>
 where
     K: Serialize + Hash + Eq,
     V: Serialize,
     S: BuildHasher,
+    Idx: Indexable,
 {
     fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
     where
@@ -25,15 +27,16 @@ where
     }
 }
 
-struct IndexMapVisitor<K, V, S>(PhantomData<(K, V, S)>);
+struct IndexMapVisitor<K, V, S, Idx>(PhantomData<(K, V, S, Idx)>);
 
-impl<'de, K, V, S> Visitor<'de> for IndexMapVisitor<K, V, S>
+impl<'de, K, V, S, Idx> Visitor<'de> for IndexMapVisitor<K, V, S, Idx>
 where
     K: Deserialize<'de> + Eq + Hash,
     V: Deserialize<'de>,
     S: Default + BuildHasher,
+    Idx: Indexable,
 {
-    type Value = IndexMap<K, V, S>;
+    type Value = IndexMap<K, V, S, Idx>;
 
     fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         write!(formatter, "a map")
@@ -55,11 +58,12 @@ where
 }
 
 /// Requires crate feature `"serde"`
-impl<'de, K, V, S> Deserialize<'de> for IndexMap<K, V, S>
+impl<'de, K, V, S, Idx> Deserialize<'de> for IndexMap<K, V, S, Idx>
 where
     K: Deserialize<'de> + Eq + Hash,
     V: Deserialize<'de>,
     S: Default + BuildHasher,
+    Idx: Indexable,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -69,11 +73,12 @@ where
     }
 }
 
-impl<'de, K, V, S, E> IntoDeserializer<'de, E> for IndexMap<K, V, S>
+impl<'de, K, V, S, Idx, E> IntoDeserializer<'de, E> for IndexMap<K, V, S, Idx>
 where
     K: IntoDeserializer<'de, E> + Eq + Hash,
     V: IntoDeserializer<'de, E>,
     S: BuildHasher,
+    Idx: Indexable,
     E: Error,
 {
     type Deserializer = MapDeserializer<'de, <Self as IntoIterator>::IntoIter, E>;
@@ -86,10 +91,11 @@ where
 use crate::IndexSet;
 
 /// Requires crate feature `"serde"`
-impl<T, S> Serialize for IndexSet<T, S>
+impl<T, S, Idx> Serialize for IndexSet<T, S, Idx>
 where
     T: Serialize + Hash + Eq,
     S: BuildHasher,
+    Idx: Indexable,
 {
     fn serialize<Se>(&self, serializer: Se) -> Result<Se::Ok, Se::Error>
     where
@@ -99,14 +105,15 @@ where
     }
 }
 
-struct IndexSetVisitor<T, S>(PhantomData<(T, S)>);
+struct IndexSetVisitor<T, S, Idx>(PhantomData<(T, S, Idx)>);
 
-impl<'de, T, S> Visitor<'de> for IndexSetVisitor<T, S>
+impl<'de, T, S, Idx> Visitor<'de> for IndexSetVisitor<T, S, Idx>
 where
     T: Deserialize<'de> + Eq + Hash,
     S: Default + BuildHasher,
+    Idx: Indexable,
 {
-    type Value = IndexSet<T, S>;
+    type Value = IndexSet<T, S, Idx>;
 
     fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         write!(formatter, "a set")
@@ -128,10 +135,11 @@ where
 }
 
 /// Requires crate feature `"serde"`
-impl<'de, T, S> Deserialize<'de> for IndexSet<T, S>
+impl<'de, T, S, Idx> Deserialize<'de> for IndexSet<T, S, Idx>
 where
     T: Deserialize<'de> + Eq + Hash,
     S: Default + BuildHasher,
+    Idx: Indexable,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -141,10 +149,11 @@ where
     }
 }
 
-impl<'de, T, S, E> IntoDeserializer<'de, E> for IndexSet<T, S>
+impl<'de, T, S, Idx, E> IntoDeserializer<'de, E> for IndexSet<T, S, Idx>
 where
     T: IntoDeserializer<'de, E> + Eq + Hash,
     S: BuildHasher,
+    Idx: Indexable,
     E: Error,
 {
     type Deserializer = SeqDeserializer<<Self as IntoIterator>::IntoIter, E>;

--- a/src/set.rs
+++ b/src/set.rs
@@ -669,9 +669,10 @@ impl<T, S, Idx: Indexable> IndexSet<T, S, Idx> {
     ///
     /// Computes in **O(1)** time.
     pub fn get_index(&self, index: Idx) -> Option<&T> {
-        self.as_entries()
-            .get(index.into_usize())
-            .map(Bucket::key_ref)
+        if let Ok(index_usize) = index.try_into() {
+            return self.as_entries().get(index_usize).map(Bucket::key_ref);
+        }
+        None
     }
 
     /// Get the first value

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,30 +1,43 @@
+use crate::Indexable;
 use core::ops::{Bound, Range, RangeBounds};
 
 pub(crate) fn third<A, B, C>(t: (A, B, C)) -> C {
     t.2
 }
 
-pub(crate) fn simplify_range<R>(range: R, len: usize) -> Range<usize>
+fn usize_bound<Idx: Indexable>(bound: Bound<&Idx>) -> Bound<usize> {
+    match bound {
+        Bound::Included(&i) => Bound::Included(i.into_usize()),
+        Bound::Excluded(&i) => Bound::Excluded(i.into_usize()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+pub(crate) fn simplify_range<R, Idx>(range: R, len: usize) -> Range<usize>
 where
-    R: RangeBounds<usize>,
+    R: RangeBounds<Idx>,
+    Idx: Indexable,
 {
-    let start = match range.start_bound() {
+    let start_bound = usize_bound(range.start_bound());
+    let start = match start_bound {
         Bound::Unbounded => 0,
-        Bound::Included(&i) if i <= len => i,
-        Bound::Excluded(&i) if i < len => i + 1,
+        Bound::Included(i) if i <= len => i,
+        Bound::Excluded(i) if i < len => i + 1,
         bound => panic!("range start {:?} should be <= length {}", bound, len),
     };
-    let end = match range.end_bound() {
+
+    let end_bound = usize_bound(range.end_bound());
+    let end = match end_bound {
         Bound::Unbounded => len,
-        Bound::Excluded(&i) if i <= len => i,
-        Bound::Included(&i) if i < len => i + 1,
+        Bound::Excluded(i) if i <= len => i,
+        Bound::Included(i) if i < len => i + 1,
         bound => panic!("range end {:?} should be <= length {}", bound, len),
     };
+
     if start > end {
         panic!(
             "range start {:?} should be <= range end {:?}",
-            range.start_bound(),
-            range.end_bound()
+            start_bound, end_bound
         );
     }
     start..end


### PR DESCRIPTION
The index type is a new generic parameter defaulting to `usize`:

    pub struct IndexSet<T, S = RandomState, Idx = usize>
    pub struct IndexMap<K, V, S = RandomState, Idx = usize>

In `no_std` builds, `S` has no default, but still `Idx = usize`.

This may be used to optimized the storage size in the raw table, for
example using a `u32` index if you know that `u32::MAX` capacity is
sufficient for you. It may also be useful to define a newtype index
custom to a particular domain, which only needs to implement the new
`Indexable` trait to be useful here.