### PR TITLE
ci: make sure test commands are `&&`-chained

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
       cargo build --verbose --features "$FEATURES" &&
       if [ -z "$SKIP_TEST" ]; then
         cargo test --verbose --features "$FEATURES" &&
-        cargo test --release --verbose --features "$FEATURES"
+        cargo test --release --verbose --features "$FEATURES" &&
         if [ "$FEATURES" = "serde-1" ]; then
           cargo test --verbose -p test-serde &&
           cargo test --release --verbose -p test-serde


### PR DESCRIPTION
The new test command added in e0c627b1bea0f directly followed the prior
command, without `&&`-chaining the result. So if the tests before it
_failed_, we wouldn't notice...