### PR TITLE
Update to hashbrown 0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: rust
 sudo: false
 matrix:
   include:
-    - rust: 1.32.0
-    - rust: 1.34.2
+    - rust: 1.36.0
     - rust: stable
       env:
        - FEATURES='serde-1'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0", optional = true, default-features = false }
 rayon = { version = "1.0", optional = true }
 
 [dependencies.hashbrown]
-version = "0.8.1"
+version = "0.9.0"
 default-features = false
 features = ["raw"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indexmap"
 edition = "2018"
-version = "1.5.2"
+version = "1.6.0"
 authors = [
 "bluss",
 "Josh Stone <cuviper@gmail.com>"

--- a/README.rst
+++ b/README.rst
@@ -66,9 +66,11 @@ which is roughly:
 Recent Changes
 ==============
 
-- Unreleased
+- 1.6.0
 
   - **MSRV**: Rust 1.36 or later is now required.
+
+  - The ``hashbrown`` dependency has been updated to version 0.9.
 
 - 1.5.2
 

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,10 @@ which is roughly:
 Recent Changes
 ==============
 
+- Unreleased
+
+  - **MSRV**: Rust 1.36 or later is now required.
+
 - 1.5.2
 
   - The new "std" feature will force the use of ``std`` for users that explicitly


### PR DESCRIPTION
Note: This increases the MSRV to Rust 1.36.