### PR TITLE
Let feature "serde" work as well as "serde-1"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ use std::vec::{self, Vec};
 mod macros;
 mod equivalent;
 mod mutable_keys;
-#[cfg(feature = "serde-1")]
+#[cfg(feature = "serde")]
 mod serde;
 mod util;
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -10,7 +10,7 @@ use core::marker::PhantomData;
 
 use crate::IndexMap;
 
-/// Requires crate feature `"serde-1"`
+/// Requires crate feature `"serde"` or `"serde-1"`
 impl<K, V, S> Serialize for IndexMap<K, V, S>
 where
     K: Serialize + Hash + Eq,
@@ -58,7 +58,7 @@ where
     }
 }
 
-/// Requires crate feature `"serde-1"`
+/// Requires crate feature `"serde"` or `"serde-1"`
 impl<'de, K, V, S> Deserialize<'de> for IndexMap<K, V, S>
 where
     K: Deserialize<'de> + Eq + Hash,
@@ -89,7 +89,7 @@ where
 
 use crate::IndexSet;
 
-/// Requires crate feature `"serde-1"`
+/// Requires crate feature `"serde"` or `"serde-1"`
 impl<T, S> Serialize for IndexSet<T, S>
 where
     T: Serialize + Hash + Eq,
@@ -135,7 +135,7 @@ where
     }
 }
 
-/// Requires crate feature `"serde-1"`
+/// Requires crate feature `"serde"` or `"serde-1"`
 impl<'de, T, S> Deserialize<'de> for IndexSet<T, S>
 where
     T: Deserialize<'de> + Eq + Hash,


### PR DESCRIPTION
The optional dependency on `serde` creates an implicit feature, but
we've only been enabling that implementation with `"serde-1"`. Now you
can directly enable `"serde"` to get full use, and `"serde-1"` is just
kept for compatibility.

If we ever need a `"serde-2"`, that can depend on package renaming.

Closes #84.