### PR TITLE
Implement functionality to shift_remove in bulk

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -718,6 +718,20 @@ impl<K, V, S> IndexMap<K, V, S> {
     pub fn shift_remove_index(&mut self, index: usize) -> Option<(K, V)> {
         self.core.shift_remove_index(index)
     }
+
+    /// Remove the key-value pairs by the provided indices.
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    ///
+    /// Like `Vec::remove`, the pairs are removed by shifting all of the
+    /// elements that follow, preserving their relative order.
+    /// **This perturbs the index of all of those elements!**
+    ///
+    /// Computes in **O(n)** time (average).
+    pub fn shift_remove_indices(&mut self, indices: &mut [usize]) {
+        self.core.shift_remove_indices(indices)
+    }
+
 }
 
 /// An iterator over the keys of a `IndexMap`.
@@ -1261,6 +1275,21 @@ mod tests {
     use super::*;
     use crate::util::enumerate;
     use std::string::String;
+
+    #[test]
+    fn shift_remove_multiple_elements() {
+        let mut map = IndexMap::new();
+        for i in 0..15 {
+            map.insert(i, ());
+        }
+        let mut second = [4, 8, 12];
+        map.shift_remove_indices(&mut second);
+        assert_eq!(map.len(), 12);
+        let expected = [0, 1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14];
+        for (e, (key, _)) in expected.iter().zip(map.iter()) {
+            assert!(key == e);
+        }
+    }
 
     #[test]
     fn it_works() {

--- a/src/map/core.rs
+++ b/src/map/core.rs
@@ -221,21 +221,6 @@ impl<K, V> IndexMapCore<K, V> {
         }
     }
 
-    // /// Remove an entry by shifting all entries that follow it
-    // pub(crate) fn shift_remove_items_full<Q>(&mut self, hash: HashValue, key: &Q) -> Option<(usize, K, V)>
-    // where
-    //     Q: ?Sized + Equivalent<K>,
-    // {
-    //     let eq = equivalent(key, &self.entries);
-    //     match self.indices.remove_entry(hash.get(), eq) {
-    //         Some(index) => {
-    //             let (key, value) = self.shift_remove_finish(index);
-    //             Some((index, key, value))
-    //         }
-    //         None => None,
-    //     }
-    // }
-
     /// Remove an entry by shifting all entries that follow it
     pub(crate) fn shift_remove_indices(&mut self, indices: &mut [usize]) {
         indices.sort();


### PR DESCRIPTION
Currently, there aren't any good options for removing multiple indices and maintaining ordering - to do so, you'd either do

```rust
    fn remove_items(&mut self, indices: Vec<usize>) {
        for index in indices {
            self.items.shift_remove_index(index);
        }
    } 
```

or

```rust
    fn remove_items(&mut self, indices: Vec<usize>) {
        for index in indices {
            self.items.remove_index(index);
        }
        self.items.sort();
    }
```

which would take O(nm) time and O(m+nlogn) time respectively, but this is pretty terrible when your IndexMap is large (eg. at 50k elements and 200 keys, you'd do almost 5 million individual shifts on average).

This implements a version which operates on a mutable array of indices (as the indices need to be sorted to go from smallest to largest). This should reduce the runtime to O(n +mlogm) for any amount of insertions, which is a massive improvement. However, it might be a bit slower than shift_remove_finish for small removals - doing a full sweep isn't possible, since identifying the correct amount to shift elements by requires a binary search on each index.

I haven't implemented it for `shift_remove_full`, since this would likely require allocating space for the indices so that they can be sorted.

This PR would allow 

```rust
    fn remove_items(&mut self, indices: &mut [usize]) {
        self.items.remove_indices(&mut indices);
    }
```

It might also be useful to allow removing ranges - but it seems that similar methods (eg. getting a slice or mutable slice of elements) are blocked from being implemented at the moment.