### PR TITLE
Fix outdated docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ indexmap
 .. |docs| image:: https://docs.rs/indexmap/badge.svg
 .. _docs: https://docs.rs/indexmap
 
-.. |rustc| image:: https://img.shields.io/badge/rust-1.32%2B-orange.svg
-.. _rustc: https://img.shields.io/badge/rust-1.32%2B-orange.svg
+.. |rustc| image:: https://img.shields.io/badge/rust-1.36%2B-orange.svg
+.. _rustc: https://img.shields.io/badge/rust-1.36%2B-orange.svg
 
 A pure-Rust hash table which preserves (in a limited sense) insertion order.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,7 @@
 //!
 //! ### Rust Version
 //!
-//! This version of indexmap requires Rust 1.32 or later, or Rust 1.36+ for
-//! using with `alloc` (without `std`), see below.
+//! This version of indexmap requires Rust 1.36 or later.
 //!
 //! The indexmap 1.x release series will use a carefully considered version
 //! upgrade policy, where in a later 1.x version, we will raise the minimum
@@ -62,7 +61,7 @@
 //!
 //! ## No Standard Library Targets
 //!
-//! From Rust 1.36, this crate supports being built without `std`, requiring
+//! This crate supports being built without `std`, requiring
 //! `alloc` instead. This is enabled automatically when it is detected that
 //! `std` is not available. There is no crate feature to enable/disable to
 //! trigger this. It can be tested by building for a std-less target.


### PR DESCRIPTION
[Seems the current MSRV is 1.36](https://github.com/bluss/indexmap/pull/152), but some docs still say it's 1.32.