### PR TITLE
Add move_index to change the position of an entry

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,6 +19,10 @@
   - The new `IndexMap::shrink_to` and `IndexSet::shrink_to` methods shrink
     the capacity with a lower bound.
 
+  - The new `IndexMap::move_index` and `IndexSet::move_index` methods change
+    the position of an item from one index to another, shifting the items
+    between to accommodate the move.
+
   - The new `map::Slice<K, V>` and `set::Slice<T>` offer a linear view of maps
     and sets, behaving a lot like normal `[(K, V)]` and `[T]` slices. Notably,
     comparison traits like `Eq` only consider items in order, rather than hash

--- a/src/map.rs
+++ b/src/map.rs
@@ -876,6 +876,19 @@ impl<K, V, S> IndexMap<K, V, S> {
         self.core.shift_remove_index(index)
     }
 
+    /// Moves the position of a key-value pair from one index to another
+    /// by shifting all other pairs in-between.
+    ///
+    /// * If `from < to`, the other pairs will shift down while the targeted pair moves up.
+    /// * If `from > to`, the other pairs will shift up while the targeted pair moves down.
+    ///
+    /// ***Panics*** if `from` or `to` are out of bounds.
+    ///
+    /// Computes in **O(n)** time (average).
+    pub fn move_index(&mut self, from: usize, to: usize) {
+        self.core.move_index(from, to)
+    }
+
     /// Swaps the position of two key-value pairs in the map.
     ///
     /// ***Panics*** if `a` or `b` are out of bounds.

--- a/src/set.rs
+++ b/src/set.rs
@@ -731,6 +731,19 @@ impl<T, S> IndexSet<T, S> {
         self.map.shift_remove_index(index).map(|(x, ())| x)
     }
 
+    /// Moves the position of a value from one index to another
+    /// by shifting all other values in-between.
+    ///
+    /// * If `from < to`, the other values will shift down while the targeted value moves up.
+    /// * If `from > to`, the other values will shift up while the targeted value moves down.
+    ///
+    /// ***Panics*** if `from` or `to` are out of bounds.
+    ///
+    /// Computes in **O(n)** time (average).
+    pub fn move_index(&mut self, from: usize, to: usize) {
+        self.map.move_index(from, to)
+    }
+
     /// Swaps the position of two values in the set.
     ///
     /// ***Panics*** if `a` or `b` are out of bounds.

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -216,6 +216,45 @@ quickcheck_limit! {
             map[&key] == value && map[i] == value
         })
     }
+
+    fn swap_indices(vec: Vec<u8>, a: usize, b: usize) -> TestResult {
+        let mut set = IndexSet::<u8>::from_iter(vec);
+        if a >= set.len() || b >= set.len() {
+            return TestResult::discard();
+        }
+
+        let mut vec = Vec::from_iter(set.iter().cloned());
+        vec.swap(a, b);
+
+        set.swap_indices(a, b);
+
+        // Check both iteration order and hash lookups
+        assert!(set.iter().eq(vec.iter()));
+        assert!(vec.iter().enumerate().all(|(i, x)| {
+            set.get_index_of(x) == Some(i)
+        }));
+        TestResult::passed()
+    }
+
+    fn move_index(vec: Vec<u8>, from: usize, to: usize) -> TestResult {
+        let mut set = IndexSet::<u8>::from_iter(vec);
+        if from >= set.len() || to >= set.len() {
+            return TestResult::discard();
+        }
+
+        let mut vec = Vec::from_iter(set.iter().cloned());
+        let x = vec.remove(from);
+        vec.insert(to, x);
+
+        set.move_index(from, to);
+
+        // Check both iteration order and hash lookups
+        assert!(set.iter().eq(vec.iter()));
+        assert!(vec.iter().enumerate().all(|(i, x)| {
+            set.get_index_of(x) == Some(i)
+        }));
+        TestResult::passed()
+    }
 }
 
 use crate::Op::*;

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -217,8 +217,12 @@ quickcheck_limit! {
         })
     }
 
-    fn swap_indices(vec: Vec<u8>, a: usize, b: usize) -> TestResult {
+    // Use `u8` test indices so quickcheck is less likely to go out of bounds.
+    fn swap_indices(vec: Vec<u8>, a: u8, b: u8) -> TestResult {
         let mut set = IndexSet::<u8>::from_iter(vec);
+        let a = usize::from(a);
+        let b = usize::from(b);
+
         if a >= set.len() || b >= set.len() {
             return TestResult::discard();
         }
@@ -236,8 +240,12 @@ quickcheck_limit! {
         TestResult::passed()
     }
 
-    fn move_index(vec: Vec<u8>, from: usize, to: usize) -> TestResult {
+    // Use `u8` test indices so quickcheck is less likely to go out of bounds.
+    fn move_index(vec: Vec<u8>, from: u8, to: u8) -> TestResult {
         let mut set = IndexSet::<u8>::from_iter(vec);
+        let from = usize::from(from);
+        let to = usize::from(to);
+
         if from >= set.len() || to >= set.len() {
             return TestResult::discard();
         }


### PR DESCRIPTION
This moves the position of a key-value pair from one index to another by
shifting all other pairs in-between, making this an O(n) operation.

This could be used as a building-block for other operations, like #173
which wants to insert at a particular index. You can `insert_full` to
insert it _somewhere_, then choose whether to `move_index` depending on
whether you want to also change pre-existing entries.