### PR TITLE
Add dynamically-sized slices of maps and sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.56.0 # MSRV
+          - rust: 1.56.1 # MSRV
             features:
           - rust: stable
             features: serde
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.56.0
+          - rust: 1.56.1
             target: thumbv6m-none-eabi
           - rust: stable
             target: thumbv6m-none-eabi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR MIT"
 description = "A hash table with consistent order and fast iteration."
 keywords = ["hashmap", "no_std"]
 categories = ["data-structures", "no-std"]
-rust-version = "1.56"
+rust-version = "1.56.1"
 
 [lib]
 bench = false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build status](https://github.com/bluss/indexmap/workflows/Continuous%20integration/badge.svg?branch=master)](https://github.com/bluss/indexmap/actions)
 [![crates.io](https://img.shields.io/crates/v/indexmap.svg)](https://crates.io/crates/indexmap)
 [![docs](https://docs.rs/indexmap/badge.svg)](https://docs.rs/indexmap)
-[![rustc](https://img.shields.io/badge/rust-1.56%2B-orange.svg)](https://img.shields.io/badge/rust-1.56%2B-orange.svg)
+[![rustc](https://img.shields.io/badge/rust-1.56.1%2B-orange.svg)](https://img.shields.io/badge/rust-1.56.1%2B-orange.svg)
 
 A pure-Rust hash table which preserves (in a limited sense) insertion order.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,6 +19,11 @@
   - The new `IndexMap::shrink_to` and `IndexSet::shrink_to` methods shrink
     the capacity with a lower bound.
 
+  - The new `map::Slice<K, V>` and `set::Slice<T>` offer a linear view of maps
+    and sets, behaving a lot like normal `[(K, V)]` and `[T]` slices. Notably,
+    comparison traits like `Eq` only consider items in order, rather than hash
+    lookups, and slices even implement `Hash`.
+
 - 1.8.1
 
   - The new `IndexSet::replace_full` will return the index of the item along

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 - 2.0.0 (pending)
 
-  - **MSRV**: Rust 1.56 or later is now required.
+  - **MSRV**: Rust 1.56.1 or later is now required.
 
   - The `hashbrown` dependency has been updated to version 0.12.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! ### Rust Version
 //!
-//! This version of indexmap requires Rust 1.56 or later.
+//! This version of indexmap requires Rust 1.56.1 or later.
 //!
 //! The indexmap 2.x release series will use a carefully considered version
 //! upgrade policy, where in a later 2.x version, we will raise the minimum

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,7 +2,9 @@
 //! pairs is independent of the hash values of the keys.
 
 mod core;
+mod slice;
 
+pub use self::slice::Slice;
 pub use crate::mutable_keys::MutableKeys;
 
 #[cfg(feature = "rayon")]

--- a/src/map.rs
+++ b/src/map.rs
@@ -17,6 +17,7 @@ use ::core::hash::{BuildHasher, Hash, Hasher};
 use ::core::iter::FusedIterator;
 use ::core::ops::{Index, IndexMut, RangeBounds};
 use ::core::slice::{Iter as SliceIter, IterMut as SliceIterMut};
+use alloc::boxed::Box;
 
 #[cfg(feature = "std")]
 use std::collections::hash_map::RandomState;
@@ -772,6 +773,13 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// Computes in **O(1)** time.
     pub fn as_mut_slice(&mut self) -> &mut Slice<K, V> {
         Slice::from_mut_slice(self.as_entries_mut())
+    }
+
+    /// Converts into a boxed slice of all the key-value pairs in the map.
+    ///
+    /// Note that this will drop the inner hash table and any excess capacity.
+    pub fn into_boxed_slice(self) -> Box<Slice<K, V>> {
+        Slice::from_boxed(self.into_entries().into_boxed_slice())
     }
 
     /// Get a key-value pair by index

--- a/src/map.rs
+++ b/src/map.rs
@@ -884,7 +884,7 @@ impl<K, V, S> IndexMap<K, V, S> {
 /// [`keys`]: struct.IndexMap.html#method.keys
 /// [`IndexMap`]: struct.IndexMap.html
 pub struct Keys<'a, K, V> {
-    pub(crate) iter: SliceIter<'a, Bucket<K, V>>,
+    iter: SliceIter<'a, Bucket<K, V>>,
 }
 
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
@@ -1176,7 +1176,7 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for IterMut<'_, K, V> {
 /// [`into_iter`]: struct.IndexMap.html#method.into_iter
 /// [`IndexMap`]: struct.IndexMap.html
 pub struct IntoIter<K, V> {
-    pub(crate) iter: vec::IntoIter<Bucket<K, V>>,
+    iter: vec::IntoIter<Bucket<K, V>>,
 }
 
 impl<K, V> Iterator for IntoIter<K, V> {

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -1,0 +1,319 @@
+use super::{Bucket, Entries, IndexMap, Iter, IterMut, Keys, Values, ValuesMut};
+
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::ops::{self, Index, IndexMut};
+
+/// A dynamically-sized slice of key-value pairs in an `IndexMap`.
+///
+/// This supports indexed operations much like a `[(K, V)]` slice,
+/// but not any hashed operations on the map keys.
+///
+/// Unlike `IndexMap`, `Slice` does consider the order for `PartialEq`
+/// and `Eq`, and it also implements `PartialOrd`, `Ord`, and `Hash`.
+#[repr(transparent)]
+pub struct Slice<K, V> {
+    entries: [Bucket<K, V>],
+}
+
+#[allow(unsafe_code)]
+impl<K, V> Slice<K, V> {
+    fn from_slice(entries: &[Bucket<K, V>]) -> &Self {
+        // SAFETY: `Slice<K, V>` is a transparent wrapper around `[Bucket<K, V>]`,
+        // and the lifetimes are bound together by this function's signature.
+        unsafe { &*(entries as *const [Bucket<K, V>] as *const Self) }
+    }
+
+    fn from_mut_slice(entries: &mut [Bucket<K, V>]) -> &mut Self {
+        // SAFETY: `Slice<K, V>` is a transparent wrapper around `[Bucket<K, V>]`,
+        // and the lifetimes are bound together by this function's signature.
+        unsafe { &mut *(entries as *mut [Bucket<K, V>] as *mut Self) }
+    }
+}
+
+impl<K, V, S> IndexMap<K, V, S> {
+    /// Returns a slice of all the entries in the map.
+    pub fn as_slice(&self) -> &Slice<K, V> {
+        Slice::from_slice(self.as_entries())
+    }
+
+    /// Returns a mutable slice of all the entries in the map.
+    pub fn as_mut_slice(&mut self) -> &mut Slice<K, V> {
+        Slice::from_mut_slice(self.as_entries_mut())
+    }
+}
+
+impl<'a, K, V> Iter<'a, K, V> {
+    /// Returns a slice of the remaining entries in the iterator.
+    pub fn as_slice(&self) -> &'a Slice<K, V> {
+        Slice::from_slice(self.iter.as_slice())
+    }
+}
+
+impl<'a, K, V> IterMut<'a, K, V> {
+    /// Returns a slice of the remaining entries in the iterator.
+    ///
+    /// To avoid creating `&mut` references that alias, this is forced to consume the iterator.
+    pub fn into_slice(self) -> &'a mut Slice<K, V> {
+        Slice::from_mut_slice(self.iter.into_slice())
+    }
+}
+
+impl<K, V> Slice<K, V> {
+    /// Return the number of key-value pairs in the map slice.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if the map slice contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Get a key-value pair by index.
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    pub fn get_index(&self, index: usize) -> Option<(&K, &V)> {
+        self.entries.get(index).map(Bucket::refs)
+    }
+
+    /// Get a key-value pair by index, with mutable access to the value.
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    pub fn get_index_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
+        // NB: we're not returning `&mut K` like `IndexMap::get_index_mut`,
+        // because that was a mistake that should have required `MutableKeys`.
+        self.entries.get_mut(index).map(Bucket::ref_mut)
+    }
+
+    /// Get the first key-value pair.
+    pub fn first(&self) -> Option<(&K, &V)> {
+        self.entries.first().map(Bucket::refs)
+    }
+
+    /// Get the first key-value pair, with mutable access to the value.
+    pub fn first_mut(&mut self) -> Option<(&K, &mut V)> {
+        self.entries.first_mut().map(Bucket::ref_mut)
+    }
+
+    /// Get the last key-value pair.
+    pub fn last(&self) -> Option<(&K, &V)> {
+        self.entries.last().map(Bucket::refs)
+    }
+
+    /// Get the last key-value pair, with mutable access to the value.
+    pub fn last_mut(&mut self) -> Option<(&K, &mut V)> {
+        self.entries.last_mut().map(Bucket::ref_mut)
+    }
+
+    /// Divides one slice into two at an index.
+    ///
+    /// ***Panics*** if `index > len`.
+    pub fn split_at(&self, index: usize) -> (&Self, &Self) {
+        let (first, second) = self.entries.split_at(index);
+        (Self::from_slice(first), Self::from_slice(second))
+    }
+
+    /// Divides one mutable slice into two at an index.
+    ///
+    /// ***Panics*** if `index > len`.
+    pub fn split_at_mut(&mut self, index: usize) -> (&mut Self, &mut Self) {
+        let (first, second) = self.entries.split_at_mut(index);
+        (Self::from_mut_slice(first), Self::from_mut_slice(second))
+    }
+
+    /// Returns the first key-value pair and the rest of the slice,
+    /// or `None` if it is empty.
+    pub fn split_first(&self) -> Option<((&K, &V), &Self)> {
+        if let Some((first, rest)) = self.entries.split_first() {
+            Some((first.refs(), Self::from_slice(rest)))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the first key-value pair and the rest of the slice,
+    /// with mutable access to the value, or `None` if it is empty.
+    pub fn split_first_mut(&mut self) -> Option<((&K, &mut V), &mut Self)> {
+        if let Some((first, rest)) = self.entries.split_first_mut() {
+            Some((first.ref_mut(), Self::from_mut_slice(rest)))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the last key-value pair and the rest of the slice,
+    /// or `None` if it is empty.
+    pub fn split_last(&self) -> Option<((&K, &V), &Self)> {
+        if let Some((last, rest)) = self.entries.split_last() {
+            Some((last.refs(), Self::from_slice(rest)))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the last key-value pair and the rest of the slice,
+    /// with mutable access to the value, or `None` if it is empty.
+    pub fn split_last_mut(&mut self) -> Option<((&K, &mut V), &mut Self)> {
+        if let Some((last, rest)) = self.entries.split_last_mut() {
+            Some((last.ref_mut(), Self::from_mut_slice(rest)))
+        } else {
+            None
+        }
+    }
+
+    /// Return an iterator over the key-value pairs of the map slice.
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        Iter {
+            iter: self.entries.iter(),
+        }
+    }
+
+    /// Return an iterator over the key-value pairs of the map slice.
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
+        IterMut {
+            iter: self.entries.iter_mut(),
+        }
+    }
+
+    /// Return an iterator over the keys of the map slice.
+    pub fn keys(&self) -> Keys<'_, K, V> {
+        Keys {
+            iter: self.entries.iter(),
+        }
+    }
+
+    /// Return an iterator over the values of the map slice.
+    pub fn values(&self) -> Values<'_, K, V> {
+        Values {
+            iter: self.entries.iter(),
+        }
+    }
+
+    /// Return an iterator over mutable references to the the values of the map slice.
+    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
+        ValuesMut {
+            iter: self.entries.iter_mut(),
+        }
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a Slice<K, V> {
+    type IntoIter = Iter<'a, K, V>;
+    type Item = (&'a K, &'a V);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a mut Slice<K, V> {
+    type IntoIter = IterMut<'a, K, V>;
+    type Item = (&'a K, &'a mut V);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<K, V> Default for &'_ Slice<K, V> {
+    fn default() -> Self {
+        Slice::from_slice(&[])
+    }
+}
+
+impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Slice<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self).finish()
+    }
+}
+
+impl<K: PartialEq, V: PartialEq> PartialEq for Slice<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().eq(other)
+    }
+}
+
+impl<K: Eq, V: Eq> Eq for Slice<K, V> {}
+
+impl<K: PartialOrd, V: PartialOrd> PartialOrd for Slice<K, V> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.iter().partial_cmp(other)
+    }
+}
+
+impl<K: Ord, V: Ord> Ord for Slice<K, V> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.iter().cmp(other)
+    }
+}
+
+impl<K: Hash, V: Hash> Hash for Slice<K, V> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.len().hash(state);
+        for (key, value) in self {
+            key.hash(state);
+            value.hash(state);
+        }
+    }
+}
+
+impl<K, V> Index<usize> for Slice<K, V> {
+    type Output = V;
+
+    fn index(&self, index: usize) -> &V {
+        &self.entries[index].value
+    }
+}
+
+impl<K, V> IndexMut<usize> for Slice<K, V> {
+    fn index_mut(&mut self, index: usize) -> &mut V {
+        &mut self.entries[index].value
+    }
+}
+
+// We can't have `impl<I: RangeBounds<usize>> Index<I>` because that conflicts
+// both upstream with `Index<usize>` and downstream with `Index<&Q>`.
+// Instead, we repeat the implementations for all the core range types.
+macro_rules! impl_index {
+    ($($range:ty),*) => {$(
+        impl<K, V, S> Index<$range> for IndexMap<K, V, S> {
+            type Output = Slice<K, V>;
+
+            fn index(&self, range: $range) -> &Self::Output {
+                Slice::from_slice(&self.as_entries()[range])
+            }
+        }
+
+        impl<K, V, S> IndexMut<$range> for IndexMap<K, V, S> {
+            fn index_mut(&mut self, range: $range) -> &mut Self::Output {
+                Slice::from_mut_slice(&mut self.as_entries_mut()[range])
+            }
+        }
+
+        impl<K, V> Index<$range> for Slice<K, V> {
+            type Output = Slice<K, V>;
+
+            fn index(&self, range: $range) -> &Self {
+                Self::from_slice(&self.entries[range])
+            }
+        }
+
+        impl<K, V> IndexMut<$range> for Slice<K, V> {
+            fn index_mut(&mut self, range: $range) -> &mut Self {
+                Self::from_mut_slice(&mut self.entries[range])
+            }
+        }
+    )*}
+}
+impl_index!(
+    ops::Range<usize>,
+    ops::RangeFrom<usize>,
+    ops::RangeFull,
+    ops::RangeInclusive<usize>,
+    ops::RangeTo<usize>,
+    ops::RangeToInclusive<usize>
+);

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -1,10 +1,10 @@
 use super::{Bucket, Entries, IndexMap, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::util::simplify_range;
+use crate::util::{simplify_range, try_simplify_range};
 
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
-use core::ops::{self, Bound, Index, IndexMut};
+use core::ops::{self, Bound, Index, IndexMut, RangeBounds};
 
 /// A dynamically-sized slice of key-value pairs in an `IndexMap`.
 ///
@@ -42,6 +42,24 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// Returns a mutable slice of all the entries in the map.
     pub fn as_mut_slice(&mut self) -> &mut Slice<K, V> {
         Slice::from_mut_slice(self.as_entries_mut())
+    }
+
+    /// Returns a slice of entries in the given range of indices.
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    pub fn get_range<R: RangeBounds<usize>>(&self, range: R) -> Option<&Slice<K, V>> {
+        let entries = self.as_entries();
+        let range = try_simplify_range(range, entries.len())?;
+        entries.get(range).map(Slice::from_slice)
+    }
+
+    /// Returns a mutable slice of entries in the given range of indices.
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    pub fn get_range_mut<R: RangeBounds<usize>>(&mut self, range: R) -> Option<&mut Slice<K, V>> {
+        let entries = self.as_entries_mut();
+        let range = try_simplify_range(range, entries.len())?;
+        entries.get_mut(range).map(Slice::from_mut_slice)
     }
 }
 
@@ -88,6 +106,22 @@ impl<K, V> Slice<K, V> {
         // NB: we're not returning `&mut K` like `IndexMap::get_index_mut`,
         // because that was a mistake that should have required `MutableKeys`.
         self.entries.get_mut(index).map(Bucket::ref_mut)
+    }
+
+    /// Returns a slice of key-value pairs in the given range of indices.
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    pub fn get_range<R: RangeBounds<usize>>(&self, range: R) -> Option<&Self> {
+        let range = try_simplify_range(range, self.entries.len())?;
+        self.entries.get(range).map(Slice::from_slice)
+    }
+
+    /// Returns a mutable slice of key-value pairs in the given range of indices.
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    pub fn get_range_mut<R: RangeBounds<usize>>(&mut self, range: R) -> Option<&mut Self> {
+        let range = try_simplify_range(range, self.entries.len())?;
+        self.entries.get_mut(range).map(Slice::from_mut_slice)
     }
 
     /// Get the first key-value pair.

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -20,62 +20,16 @@ pub struct Slice<K, V> {
 
 #[allow(unsafe_code)]
 impl<K, V> Slice<K, V> {
-    fn from_slice(entries: &[Bucket<K, V>]) -> &Self {
+    pub(super) fn from_slice(entries: &[Bucket<K, V>]) -> &Self {
         // SAFETY: `Slice<K, V>` is a transparent wrapper around `[Bucket<K, V>]`,
         // and the lifetimes are bound together by this function's signature.
         unsafe { &*(entries as *const [Bucket<K, V>] as *const Self) }
     }
 
-    fn from_mut_slice(entries: &mut [Bucket<K, V>]) -> &mut Self {
+    pub(super) fn from_mut_slice(entries: &mut [Bucket<K, V>]) -> &mut Self {
         // SAFETY: `Slice<K, V>` is a transparent wrapper around `[Bucket<K, V>]`,
         // and the lifetimes are bound together by this function's signature.
         unsafe { &mut *(entries as *mut [Bucket<K, V>] as *mut Self) }
-    }
-}
-
-impl<K, V, S> IndexMap<K, V, S> {
-    /// Returns a slice of all the entries in the map.
-    pub fn as_slice(&self) -> &Slice<K, V> {
-        Slice::from_slice(self.as_entries())
-    }
-
-    /// Returns a mutable slice of all the entries in the map.
-    pub fn as_mut_slice(&mut self) -> &mut Slice<K, V> {
-        Slice::from_mut_slice(self.as_entries_mut())
-    }
-
-    /// Returns a slice of entries in the given range of indices.
-    ///
-    /// Valid indices are *0 <= index < self.len()*
-    pub fn get_range<R: RangeBounds<usize>>(&self, range: R) -> Option<&Slice<K, V>> {
-        let entries = self.as_entries();
-        let range = try_simplify_range(range, entries.len())?;
-        entries.get(range).map(Slice::from_slice)
-    }
-
-    /// Returns a mutable slice of entries in the given range of indices.
-    ///
-    /// Valid indices are *0 <= index < self.len()*
-    pub fn get_range_mut<R: RangeBounds<usize>>(&mut self, range: R) -> Option<&mut Slice<K, V>> {
-        let entries = self.as_entries_mut();
-        let range = try_simplify_range(range, entries.len())?;
-        entries.get_mut(range).map(Slice::from_mut_slice)
-    }
-}
-
-impl<'a, K, V> Iter<'a, K, V> {
-    /// Returns a slice of the remaining entries in the iterator.
-    pub fn as_slice(&self) -> &'a Slice<K, V> {
-        Slice::from_slice(self.iter.as_slice())
-    }
-}
-
-impl<'a, K, V> IterMut<'a, K, V> {
-    /// Returns a slice of the remaining entries in the iterator.
-    ///
-    /// To avoid creating `&mut` references that alias, this is forced to consume the iterator.
-    pub fn into_slice(self) -> &'a mut Slice<K, V> {
-        Slice::from_mut_slice(self.iter.into_slice())
     }
 }
 

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -14,7 +14,7 @@ use core::ops::{self, Index, IndexMut};
 /// and `Eq`, and it also implements `PartialOrd`, `Ord`, and `Hash`.
 #[repr(transparent)]
 pub struct Slice<K, V> {
-    entries: [Bucket<K, V>],
+    pub(crate) entries: [Bucket<K, V>],
 }
 
 #[allow(unsafe_code)]

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -396,3 +396,119 @@ impl<K, V> IndexMut<(Bound<usize>, Bound<usize>)> for Slice<K, V> {
         Slice::from_mut_slice(&mut entries[range])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn slice_index() {
+        fn check(
+            vec_slice: &[(i32, i32)],
+            map_slice: &Slice<i32, i32>,
+            sub_slice: &Slice<i32, i32>,
+        ) {
+            assert_eq!(map_slice as *const _, sub_slice as *const _);
+            itertools::assert_equal(
+                vec_slice.iter().copied(),
+                map_slice.iter().map(|(&k, &v)| (k, v)),
+            );
+            itertools::assert_equal(vec_slice.iter().map(|(k, _)| k), map_slice.keys());
+            itertools::assert_equal(vec_slice.iter().map(|(_, v)| v), map_slice.values());
+        }
+
+        let vec: Vec<(i32, i32)> = (0..10).map(|i| (i, i * i)).collect();
+        let map: IndexMap<i32, i32> = vec.iter().cloned().collect();
+        let slice = map.as_slice();
+
+        // RangeFull
+        check(&vec[..], &map[..], &slice[..]);
+
+        for i in 0usize..10 {
+            // Index
+            assert_eq!(vec[i].1, map[i]);
+            assert_eq!(vec[i].1, slice[i]);
+            assert_eq!(map[&(i as i32)], map[i]);
+            assert_eq!(map[&(i as i32)], slice[i]);
+
+            // RangeFrom
+            check(&vec[i..], &map[i..], &slice[i..]);
+
+            // RangeTo
+            check(&vec[..i], &map[..i], &slice[..i]);
+
+            // RangeToInclusive
+            check(&vec[..=i], &map[..=i], &slice[..=i]);
+
+            // (Bound<usize>, Bound<usize>)
+            let bounds = (Bound::Excluded(i), Bound::Unbounded);
+            check(&vec[i + 1..], &map[bounds], &slice[bounds]);
+
+            for j in i..=10 {
+                // Range
+                check(&vec[i..j], &map[i..j], &slice[i..j]);
+            }
+
+            for j in i..10 {
+                // RangeInclusive
+                check(&vec[i..=j], &map[i..=j], &slice[i..=j]);
+            }
+        }
+    }
+
+    #[test]
+    fn slice_index_mut() {
+        fn check_mut(
+            vec_slice: &[(i32, i32)],
+            map_slice: &mut Slice<i32, i32>,
+            sub_slice: &mut Slice<i32, i32>,
+        ) {
+            assert_eq!(map_slice, sub_slice);
+            itertools::assert_equal(
+                vec_slice.iter().copied(),
+                map_slice.iter_mut().map(|(&k, &mut v)| (k, v)),
+            );
+            itertools::assert_equal(
+                vec_slice.iter().map(|&(_, v)| v),
+                map_slice.values_mut().map(|&mut v| v),
+            );
+        }
+
+        let vec: Vec<(i32, i32)> = (0..10).map(|i| (i, i * i)).collect();
+        let mut map: IndexMap<i32, i32> = vec.iter().cloned().collect();
+        let mut map2 = map.clone();
+        let slice = map2.as_mut_slice();
+
+        // RangeFull
+        check_mut(&vec[..], &mut map[..], &mut slice[..]);
+
+        for i in 0usize..10 {
+            // IndexMut
+            assert_eq!(&mut map[i], &mut slice[i]);
+
+            // RangeFrom
+            check_mut(&vec[i..], &mut map[i..], &mut slice[i..]);
+
+            // RangeTo
+            check_mut(&vec[..i], &mut map[..i], &mut slice[..i]);
+
+            // RangeToInclusive
+            check_mut(&vec[..=i], &mut map[..=i], &mut slice[..=i]);
+
+            // (Bound<usize>, Bound<usize>)
+            let bounds = (Bound::Excluded(i), Bound::Unbounded);
+            check_mut(&vec[i + 1..], &mut map[bounds], &mut slice[bounds]);
+
+            for j in i..=10 {
+                // Range
+                check_mut(&vec[i..j], &mut map[i..j], &mut slice[i..j]);
+            }
+
+            for j in i..10 {
+                // RangeInclusive
+                check_mut(&vec[i..=j], &mut map[i..=j], &mut slice[i..=j]);
+            }
+        }
+    }
+}

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -260,6 +260,12 @@ impl<K, V> Default for &'_ Slice<K, V> {
     }
 }
 
+impl<K, V> Default for &'_ mut Slice<K, V> {
+    fn default() -> Self {
+        Slice::from_mut_slice(&mut [])
+    }
+}
+
 impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Slice<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self).finish()

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -57,8 +57,6 @@ impl<K, V> Slice<K, V> {
     ///
     /// Valid indices are *0 <= index < self.len()*
     pub fn get_index_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
-        // NB: we're not returning `&mut K` like `IndexMap::get_index_mut`,
-        // because that was a mistake that should have required `MutableKeys`.
         self.entries.get_mut(index).map(Bucket::ref_mut)
     }
 

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -258,6 +258,24 @@ impl<K, V> Default for &'_ mut Slice<K, V> {
     }
 }
 
+impl<K, V> Default for Box<Slice<K, V>> {
+    fn default() -> Self {
+        Slice::from_boxed(Box::default())
+    }
+}
+
+impl<K: Clone, V: Clone> Clone for Box<Slice<K, V>> {
+    fn clone(&self) -> Self {
+        Slice::from_boxed(self.entries.to_vec().into_boxed_slice())
+    }
+}
+
+impl<K: Copy, V: Copy> From<&Slice<K, V>> for Box<Slice<K, V>> {
+    fn from(slice: &Slice<K, V>) -> Self {
+        Slice::from_boxed(slice.entries.to_vec().into_boxed_slice())
+    }
+}
+
 impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Slice<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self).finish()

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -272,7 +272,7 @@ impl<K: Clone, V: Clone> Clone for Box<Slice<K, V>> {
 
 impl<K: Copy, V: Copy> From<&Slice<K, V>> for Box<Slice<K, V>> {
     fn from(slice: &Slice<K, V>) -> Self {
-        Slice::from_boxed(slice.entries.to_vec().into_boxed_slice())
+        Slice::from_boxed(Box::from(&slice.entries))
     }
 }
 

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -1,5 +1,5 @@
 use super::{Bucket, Entries, IndexMap, Iter, IterMut, Keys, Values, ValuesMut};
-use crate::util::{simplify_range, try_simplify_range};
+use crate::util::try_simplify_range;
 
 use core::cmp::Ordering;
 use core::fmt;
@@ -308,46 +308,9 @@ impl_index!(
     ops::RangeFull,
     ops::RangeInclusive<usize>,
     ops::RangeTo<usize>,
-    ops::RangeToInclusive<usize>
+    ops::RangeToInclusive<usize>,
+    (Bound<usize>, Bound<usize>)
 );
-
-// NB: with MSRV 1.53, we can forward `Bound` pairs to direct slice indexing like other ranges
-
-impl<K, V, S> Index<(Bound<usize>, Bound<usize>)> for IndexMap<K, V, S> {
-    type Output = Slice<K, V>;
-
-    fn index(&self, range: (Bound<usize>, Bound<usize>)) -> &Self::Output {
-        let entries = self.as_entries();
-        let range = simplify_range(range, entries.len());
-        Slice::from_slice(&entries[range])
-    }
-}
-
-impl<K, V, S> IndexMut<(Bound<usize>, Bound<usize>)> for IndexMap<K, V, S> {
-    fn index_mut(&mut self, range: (Bound<usize>, Bound<usize>)) -> &mut Self::Output {
-        let entries = self.as_entries_mut();
-        let range = simplify_range(range, entries.len());
-        Slice::from_mut_slice(&mut entries[range])
-    }
-}
-
-impl<K, V> Index<(Bound<usize>, Bound<usize>)> for Slice<K, V> {
-    type Output = Slice<K, V>;
-
-    fn index(&self, range: (Bound<usize>, Bound<usize>)) -> &Self {
-        let entries = &self.entries;
-        let range = simplify_range(range, entries.len());
-        Slice::from_slice(&entries[range])
-    }
-}
-
-impl<K, V> IndexMut<(Bound<usize>, Bound<usize>)> for Slice<K, V> {
-    fn index_mut(&mut self, range: (Bound<usize>, Bound<usize>)) -> &mut Self {
-        let entries = &mut self.entries;
-        let range = simplify_range(range, entries.len());
-        Slice::from_mut_slice(&mut entries[range])
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -10,6 +10,7 @@ use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
 use rayon::prelude::*;
 
 use crate::vec::Vec;
+use alloc::boxed::Box;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
@@ -22,6 +23,22 @@ use crate::IndexMap;
 
 /// Requires crate feature `"rayon"`.
 impl<K, V, S> IntoParallelIterator for IndexMap<K, V, S>
+where
+    K: Send,
+    V: Send,
+{
+    type Item = (K, V);
+    type Iter = IntoParIter<K, V>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        IntoParIter {
+            entries: self.into_entries(),
+        }
+    }
+}
+
+/// Requires crate feature `"rayon"`.
+impl<K, V> IntoParallelIterator for Box<Slice<K, V>>
 where
     K: Send,
     V: Send,

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -10,6 +10,7 @@ use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
 use rayon::prelude::*;
 
 use crate::vec::Vec;
+use alloc::boxed::Box;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
@@ -23,6 +24,21 @@ type Bucket<T> = crate::Bucket<T, ()>;
 
 /// Requires crate feature `"rayon"`.
 impl<T, S> IntoParallelIterator for IndexSet<T, S>
+where
+    T: Send,
+{
+    type Item = T;
+    type Iter = IntoParIter<T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        IntoParIter {
+            entries: self.into_entries(),
+        }
+    }
+}
+
+/// Requires crate feature `"rayon"`.
+impl<T> IntoParallelIterator for Box<Slice<T>>
 where
     T: Send,
 {

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -15,6 +15,7 @@ use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::ops::RangeBounds;
 
+use crate::set::Slice;
 use crate::Entries;
 use crate::IndexSet;
 
@@ -74,6 +75,21 @@ where
     fn into_par_iter(self) -> Self::Iter {
         ParIter {
             entries: self.as_entries(),
+        }
+    }
+}
+
+/// Requires crate feature `"rayon"`.
+impl<'a, T> IntoParallelIterator for &'a Slice<T>
+where
+    T: Sync,
+{
+    type Item = &'a T;
+    type Iter = ParIter<'a, T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        ParIter {
+            entries: &self.entries,
         }
     }
 }

--- a/src/serde_seq.rs
+++ b/src/serde_seq.rs
@@ -28,6 +28,42 @@ use core::hash::{BuildHasher, Hash};
 use core::marker::PhantomData;
 
 use crate::IndexMap;
+use crate::map::Slice as MapSlice;
+use crate::set::Slice as SetSlice;
+
+/// Serializes a `map::Slice` as an ordered sequence.
+///
+/// This behaves like [`crate::serde_seq`] for `IndexMap`, serializing a sequence
+/// of `(key, value)` pairs, rather than as a map that might not preserver order.
+///
+/// Requires crate feature `"serde"` or `"serde-1"`
+impl<K, V> Serialize for MapSlice<K, V>
+where
+    K: Serialize,
+    V: Serialize,
+{
+    fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
+    where
+        T: Serializer,
+    {
+        serializer.collect_seq(self)
+    }
+}
+
+/// Serializes a `set::Slice` as an ordered sequence.
+///
+/// Requires crate feature `"serde"` or `"serde-1"`
+impl<T> Serialize for SetSlice<T>
+where
+    T: Serialize,
+{
+    fn serialize<Se>(&self, serializer: Se) -> Result<Se::Ok, Se::Error>
+    where
+        Se: Serializer,
+    {
+        serializer.collect_seq(self)
+    }
+}
 
 /// Serializes an `IndexMap` as an ordered sequence.
 ///

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,5 +1,9 @@
 //! A hash set implemented using `IndexMap`
 
+mod slice;
+
+pub use self::slice::Slice;
+
 #[cfg(feature = "rayon")]
 pub use crate::rayon::set as rayon;
 
@@ -12,7 +16,7 @@ use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::iter::{Chain, FusedIterator};
 use core::ops::{BitAnd, BitOr, BitXor, Index, RangeBounds, Sub};
-use core::slice;
+use core::slice::Iter as SliceIter;
 
 use super::{Entries, Equivalent, IndexMap};
 
@@ -192,7 +196,7 @@ impl<T, S> IndexSet<T, S> {
     /// Return an iterator over the values of the set, in their order
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
-            iter: self.map.keys().iter,
+            iter: self.map.as_entries().iter(),
         }
     }
 
@@ -791,7 +795,7 @@ impl<T: fmt::Debug> fmt::Debug for IntoIter<T> {
 /// [`IndexSet`]: struct.IndexSet.html
 /// [`iter`]: struct.IndexSet.html#method.iter
 pub struct Iter<'a, T> {
-    iter: slice::Iter<'a, Bucket<T>>,
+    iter: SliceIter<'a, Bucket<T>>,
 }
 
 impl<'a, T> Iterator for Iter<'a, T> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -12,6 +12,7 @@ use std::collections::hash_map::RandomState;
 
 use crate::util::try_simplify_range;
 use crate::vec::{self, Vec};
+use alloc::boxed::Box;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
@@ -661,6 +662,13 @@ impl<T, S> IndexSet<T, S> {
     /// Computes in **O(1)** time.
     pub fn as_slice(&self) -> &Slice<T> {
         Slice::from_slice(self.as_entries())
+    }
+
+    /// Converts into a boxed slice of all the values in the set.
+    ///
+    /// Note that this will drop the inner hash table and any excess capacity.
+    pub fn into_boxed_slice(self) -> Box<Slice<T>> {
+        Slice::from_boxed(self.into_entries().into_boxed_slice())
     }
 
     /// Get a value by index

--- a/src/set.rs
+++ b/src/set.rs
@@ -607,8 +607,10 @@ where
     where
         F: FnMut(&T, &T) -> Ordering,
     {
+        let mut entries = self.into_entries();
+        entries.sort_by(move |a, b| cmp(&a.key, &b.key));
         IntoIter {
-            iter: self.map.sorted_by(move |a, _, b, _| cmp(a, b)).iter,
+            iter: entries.into_iter(),
         }
     }
 
@@ -638,11 +640,10 @@ where
     where
         F: FnMut(&T, &T) -> Ordering,
     {
+        let mut entries = self.into_entries();
+        entries.sort_unstable_by(move |a, b| cmp(&a.key, &b.key));
         IntoIter {
-            iter: self
-                .map
-                .sorted_unstable_by(move |a, _, b, _| cmp(a, b))
-                .iter,
+            iter: entries.into_iter(),
         }
     }
 
@@ -907,7 +908,7 @@ impl<T, S> IntoIterator for IndexSet<T, S> {
 
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
-            iter: self.map.into_iter().iter,
+            iter: self.into_entries().into_iter(),
         }
     }
 }

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -1,0 +1,193 @@
+use super::{Bucket, Entries, IndexSet, Iter};
+
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::ops::{self, Index};
+
+/// A dynamically-sized slice of values in an `IndexSet`.
+///
+/// This supports indexed operations much like a `[T]` slice,
+/// but not any hashed operations on the values.
+///
+/// Unlike `IndexSet`, `Slice` does consider the order for `PartialEq`
+/// and `Eq`, and it also implements `PartialOrd`, `Ord`, and `Hash`.
+#[repr(transparent)]
+pub struct Slice<T> {
+    entries: [Bucket<T>],
+}
+
+#[allow(unsafe_code)]
+impl<T> Slice<T> {
+    fn from_slice(entries: &[Bucket<T>]) -> &Self {
+        // SAFETY: `Slice<T>` is a transparent wrapper around `[Bucket<T>]`,
+        // and the lifetimes are bound together by this function's signature.
+        unsafe { &*(entries as *const [Bucket<T>] as *const Self) }
+    }
+}
+
+impl<T, S> IndexSet<T, S> {
+    /// Returns a slice of all the values in the set.
+    pub fn as_slice(&self) -> &Slice<T> {
+        Slice::from_slice(self.as_entries())
+    }
+}
+
+impl<'a, T> Iter<'a, T> {
+    /// Returns a slice of the remaining entries in the iterator.
+    pub fn as_slice(&self) -> &'a Slice<T> {
+        Slice::from_slice(self.iter.as_slice())
+    }
+}
+
+impl<T> Slice<T> {
+    /// Return the number of elements in the set slice.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if the set slice contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Get a value by index.
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    pub fn get_index(&self, index: usize) -> Option<&T> {
+        self.entries.get(index).map(Bucket::key_ref)
+    }
+
+    /// Get the first value.
+    pub fn first(&self) -> Option<&T> {
+        self.entries.first().map(Bucket::key_ref)
+    }
+
+    /// Get the last value.
+    pub fn last(&self) -> Option<&T> {
+        self.entries.last().map(Bucket::key_ref)
+    }
+
+    /// Divides one slice into two at an index.
+    ///
+    /// ***Panics*** if `index > len`.
+    pub fn split_at(&self, index: usize) -> (&Self, &Self) {
+        let (first, second) = self.entries.split_at(index);
+        (Self::from_slice(first), Self::from_slice(second))
+    }
+
+    /// Returns the first value and the rest of the slice,
+    /// or `None` if it is empty.
+    pub fn split_first(&self) -> Option<(&T, &Self)> {
+        if let Some((first, rest)) = self.entries.split_first() {
+            Some((&first.key, Self::from_slice(rest)))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the last value and the rest of the slice,
+    /// or `None` if it is empty.
+    pub fn split_last(&self) -> Option<(&T, &Self)> {
+        if let Some((last, rest)) = self.entries.split_last() {
+            Some((&last.key, Self::from_slice(rest)))
+        } else {
+            None
+        }
+    }
+
+    /// Return an iterator over the values of the set slice.
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter {
+            iter: self.entries.iter(),
+        }
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Slice<T> {
+    type IntoIter = Iter<'a, T>;
+    type Item = &'a T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<T> Default for &'_ Slice<T> {
+    fn default() -> Self {
+        Slice::from_slice(&[])
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Slice<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self).finish()
+    }
+}
+
+impl<T: PartialEq> PartialEq for Slice<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().eq(other)
+    }
+}
+
+impl<T: Eq> Eq for Slice<T> {}
+
+impl<T: PartialOrd> PartialOrd for Slice<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.iter().partial_cmp(other)
+    }
+}
+
+impl<T: Ord> Ord for Slice<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.iter().cmp(other)
+    }
+}
+
+impl<T: Hash> Hash for Slice<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.len().hash(state);
+        for value in self {
+            value.hash(state);
+        }
+    }
+}
+
+impl<T> Index<usize> for Slice<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.entries[index].key
+    }
+}
+
+// We can't have `impl<I: RangeBounds<usize>> Index<I>` because that conflicts with `Index<usize>`.
+// Instead, we repeat the implementations for all the core range types.
+macro_rules! impl_index {
+    ($($range:ty),*) => {$(
+        impl<T, S> Index<$range> for IndexSet<T, S> {
+            type Output = Slice<T>;
+
+            fn index(&self, range: $range) -> &Self::Output {
+                Slice::from_slice(&self.as_entries()[range])
+            }
+        }
+
+        impl<T> Index<$range> for Slice<T> {
+            type Output = Self;
+
+            fn index(&self, range: $range) -> &Self::Output {
+                Slice::from_slice(&self.entries[range])
+            }
+        }
+    )*}
+}
+impl_index!(
+    ops::Range<usize>,
+    ops::RangeFrom<usize>,
+    ops::RangeFull,
+    ops::RangeInclusive<usize>,
+    ops::RangeTo<usize>,
+    ops::RangeToInclusive<usize>
+);

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -20,33 +20,10 @@ pub struct Slice<T> {
 
 #[allow(unsafe_code)]
 impl<T> Slice<T> {
-    fn from_slice(entries: &[Bucket<T>]) -> &Self {
+    pub(super) fn from_slice(entries: &[Bucket<T>]) -> &Self {
         // SAFETY: `Slice<T>` is a transparent wrapper around `[Bucket<T>]`,
         // and the lifetimes are bound together by this function's signature.
         unsafe { &*(entries as *const [Bucket<T>] as *const Self) }
-    }
-}
-
-impl<T, S> IndexSet<T, S> {
-    /// Returns a slice of all the values in the set.
-    pub fn as_slice(&self) -> &Slice<T> {
-        Slice::from_slice(self.as_entries())
-    }
-
-    /// Returns a slice of values in the given range of indices.
-    ///
-    /// Valid indices are *0 <= index < self.len()*
-    pub fn get_range<R: RangeBounds<usize>>(&self, range: R) -> Option<&Slice<T>> {
-        let entries = self.as_entries();
-        let range = try_simplify_range(range, entries.len())?;
-        entries.get(range).map(Slice::from_slice)
-    }
-}
-
-impl<'a, T> Iter<'a, T> {
-    /// Returns a slice of the remaining entries in the iterator.
-    pub fn as_slice(&self) -> &'a Slice<T> {
-        Slice::from_slice(self.iter.as_slice())
     }
 }
 

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -1,9 +1,10 @@
 use super::{Bucket, Entries, IndexSet, Iter};
+use crate::util::simplify_range;
 
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
-use core::ops::{self, Index};
+use core::ops::{self, Bound, Index};
 
 /// A dynamically-sized slice of values in an `IndexSet`.
 ///
@@ -191,3 +192,25 @@ impl_index!(
     ops::RangeTo<usize>,
     ops::RangeToInclusive<usize>
 );
+
+// NB: with MSRV 1.53, we can forward `Bound` pairs to direct slice indexing like other ranges
+
+impl<T, S> Index<(Bound<usize>, Bound<usize>)> for IndexSet<T, S> {
+    type Output = Slice<T>;
+
+    fn index(&self, range: (Bound<usize>, Bound<usize>)) -> &Self::Output {
+        let entries = self.as_entries();
+        let range = simplify_range(range, entries.len());
+        Slice::from_slice(&entries[range])
+    }
+}
+
+impl<T> Index<(Bound<usize>, Bound<usize>)> for Slice<T> {
+    type Output = Self;
+
+    fn index(&self, range: (Bound<usize>, Bound<usize>)) -> &Self::Output {
+        let entries = &self.entries;
+        let range = simplify_range(range, entries.len());
+        Slice::from_slice(&entries[range])
+    }
+}

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -14,7 +14,7 @@ use core::ops::{self, Index};
 /// and `Eq`, and it also implements `PartialOrd`, `Ord`, and `Hash`.
 #[repr(transparent)]
 pub struct Slice<T> {
-    entries: [Bucket<T>],
+    pub(crate) entries: [Bucket<T>],
 }
 
 #[allow(unsafe_code)]

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -139,6 +139,24 @@ impl<T> Default for &'_ Slice<T> {
     }
 }
 
+impl<T> Default for Box<Slice<T>> {
+    fn default() -> Self {
+        Slice::from_boxed(Box::default())
+    }
+}
+
+impl<T: Clone> Clone for Box<Slice<T>> {
+    fn clone(&self) -> Self {
+        Slice::from_boxed(self.entries.to_vec().into_boxed_slice())
+    }
+}
+
+impl<T: Copy> From<&Slice<T>> for Box<Slice<T>> {
+    fn from(slice: &Slice<T>) -> Self {
+        Slice::from_boxed(slice.entries.to_vec().into_boxed_slice())
+    }
+}
+
 impl<T: fmt::Debug> fmt::Debug for Slice<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self).finish()

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -1,5 +1,5 @@
 use super::{Bucket, Entries, IndexSet, Iter};
-use crate::util::{simplify_range, try_simplify_range};
+use crate::util::try_simplify_range;
 
 use core::cmp::Ordering;
 use core::fmt;
@@ -184,30 +184,9 @@ impl_index!(
     ops::RangeFull,
     ops::RangeInclusive<usize>,
     ops::RangeTo<usize>,
-    ops::RangeToInclusive<usize>
+    ops::RangeToInclusive<usize>,
+    (Bound<usize>, Bound<usize>)
 );
-
-// NB: with MSRV 1.53, we can forward `Bound` pairs to direct slice indexing like other ranges
-
-impl<T, S> Index<(Bound<usize>, Bound<usize>)> for IndexSet<T, S> {
-    type Output = Slice<T>;
-
-    fn index(&self, range: (Bound<usize>, Bound<usize>)) -> &Self::Output {
-        let entries = self.as_entries();
-        let range = simplify_range(range, entries.len());
-        Slice::from_slice(&entries[range])
-    }
-}
-
-impl<T> Index<(Bound<usize>, Bound<usize>)> for Slice<T> {
-    type Output = Self;
-
-    fn index(&self, range: (Bound<usize>, Bound<usize>)) -> &Self::Output {
-        let entries = &self.entries;
-        let range = simplify_range(range, entries.len());
-        Slice::from_slice(&entries[range])
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -153,7 +153,7 @@ impl<T: Clone> Clone for Box<Slice<T>> {
 
 impl<T: Copy> From<&Slice<T>> for Box<Slice<T>> {
     fn from(slice: &Slice<T>) -> Self {
-        Slice::from_boxed(slice.entries.to_vec().into_boxed_slice())
+        Slice::from_boxed(Box::from(&slice.entries))
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -29,3 +29,25 @@ where
     }
     start..end
 }
+
+pub(crate) fn try_simplify_range<R>(range: R, len: usize) -> Option<Range<usize>>
+where
+    R: RangeBounds<usize>,
+{
+    let start = match range.start_bound() {
+        Bound::Unbounded => 0,
+        Bound::Included(&i) if i <= len => i,
+        Bound::Excluded(&i) if i < len => i + 1,
+        _ => return None,
+    };
+    let end = match range.end_bound() {
+        Bound::Unbounded => len,
+        Bound::Excluded(&i) if i <= len => i,
+        Bound::Included(&i) if i < len => i + 1,
+        _ => return None,
+    };
+    if start > end {
+        return None;
+    }
+    Some(start..end)
+}


### PR DESCRIPTION
Both `map::Slice<K, V>` and `set::Slice<T>` are true DSTs, simply wrapping `[Bucket]`, created by reference either indexing with ranges or calling `as_slice()` or `as_mut_slice()`. They support many of the normal indexing methods of slices, like splitting, but nothing that would change the order or require hashing. They also reuse the iterator types from map and set. `Slice` equality _does_ consider the order of the elements, and this is followed by `PartialOrd`, `Ord`, and `Hash` as well.