### PR TITLE
Prefer copied() iterators instead of cloned()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bench = false
 autocfg = "1"
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }
-rayon = { version = "1.0", optional = true }
+rayon = { version = "1.2", optional = true }
 
 [dependencies.hashbrown]
 version = "0.9.1"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -561,7 +561,7 @@ fn indexmap_merge_shuffle(b: &mut Bencher) {
 #[bench]
 fn swap_remove_indexmap_100_000(b: &mut Bencher) {
     let map = IMAP_100K.clone();
-    let mut keys = Vec::from_iter(map.keys().cloned());
+    let mut keys = Vec::from_iter(map.keys().copied());
     let mut rng = small_rng();
     keys.shuffle(&mut rng);
 
@@ -578,7 +578,7 @@ fn swap_remove_indexmap_100_000(b: &mut Bencher) {
 #[bench]
 fn shift_remove_indexmap_100_000_few(b: &mut Bencher) {
     let map = IMAP_100K.clone();
-    let mut keys = Vec::from_iter(map.keys().cloned());
+    let mut keys = Vec::from_iter(map.keys().copied());
     let mut rng = small_rng();
     keys.shuffle(&mut rng);
     keys.truncate(50);

--- a/src/map.rs
+++ b/src/map.rs
@@ -1674,7 +1674,7 @@ mod tests {
     fn keys() {
         let vec = vec![(1, 'a'), (2, 'b'), (3, 'c')];
         let map: IndexMap<_, _> = vec.into_iter().collect();
-        let keys: Vec<_> = map.keys().cloned().collect();
+        let keys: Vec<_> = map.keys().copied().collect();
         assert_eq!(keys.len(), 3);
         assert!(keys.contains(&1));
         assert!(keys.contains(&2));
@@ -1685,7 +1685,7 @@ mod tests {
     fn values() {
         let vec = vec![(1, 'a'), (2, 'b'), (3, 'c')];
         let map: IndexMap<_, _> = vec.into_iter().collect();
-        let values: Vec<_> = map.values().cloned().collect();
+        let values: Vec<_> = map.values().copied().collect();
         assert_eq!(values.len(), 3);
         assert!(values.contains(&'a'));
         assert!(values.contains(&'b'));
@@ -1699,7 +1699,7 @@ mod tests {
         for value in map.values_mut() {
             *value *= 2
         }
-        let values: Vec<_> = map.values().cloned().collect();
+        let values: Vec<_> = map.values().copied().collect();
         assert_eq!(values.len(), 3);
         assert!(values.contains(&2));
         assert!(values.contains(&4));

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -464,7 +464,7 @@ mod tests {
     fn keys() {
         let vec = vec![(1, 'a'), (2, 'b'), (3, 'c')];
         let map: IndexMap<_, _> = vec.into_par_iter().collect();
-        let keys: Vec<_> = map.par_keys().cloned().collect();
+        let keys: Vec<_> = map.par_keys().copied().collect();
         assert_eq!(keys.len(), 3);
         assert!(keys.contains(&1));
         assert!(keys.contains(&2));
@@ -475,7 +475,7 @@ mod tests {
     fn values() {
         let vec = vec![(1, 'a'), (2, 'b'), (3, 'c')];
         let map: IndexMap<_, _> = vec.into_par_iter().collect();
-        let values: Vec<_> = map.par_values().cloned().collect();
+        let values: Vec<_> = map.par_values().copied().collect();
         assert_eq!(values.len(), 3);
         assert!(values.contains(&'a'));
         assert!(values.contains(&'b'));
@@ -487,7 +487,7 @@ mod tests {
         let vec = vec![(1, 1), (2, 2), (3, 3)];
         let mut map: IndexMap<_, _> = vec.into_par_iter().collect();
         map.par_values_mut().for_each(|value| *value *= 2);
-        let values: Vec<_> = map.par_values().cloned().collect();
+        let values: Vec<_> = map.par_values().copied().collect();
         assert_eq!(values.len(), 3);
         assert!(values.contains(&2));
         assert!(values.contains(&4));

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -622,7 +622,7 @@ mod tests {
             I1: ParallelIterator<Item = &'a i32>,
             I2: Iterator<Item = i32>,
         {
-            let v1: Vec<_> = iter1.cloned().collect();
+            let v1: Vec<_> = iter1.copied().collect();
             let v2: Vec<_> = iter2.collect();
             assert_eq!(v1, v2);
         }

--- a/src/set.rs
+++ b/src/set.rs
@@ -840,7 +840,7 @@ where
     S: BuildHasher,
 {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iterable: I) {
-        let iter = iterable.into_iter().cloned(); // FIXME: use `copied` in Rust 1.36
+        let iter = iterable.into_iter().copied();
         self.extend(iter);
     }
 }
@@ -1560,7 +1560,7 @@ mod tests {
             I1: Iterator<Item = &'a i32>,
             I2: Iterator<Item = i32>,
         {
-            assert!(iter1.cloned().eq(iter2));
+            assert!(iter1.copied().eq(iter2));
         }
 
         let set_a: IndexSet<_> = (0..3).collect();

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -30,7 +30,7 @@ where
     I: IntoIterator<Item = &'a T>,
     T: Copy + Hash + Eq,
 {
-    iter.into_iter().cloned().collect()
+    iter.into_iter().copied().collect()
 }
 
 fn indexmap<'a, T: 'a, I>(iter: I) -> IndexMap<T, ()>
@@ -38,7 +38,7 @@ where
     I: IntoIterator<Item = &'a T>,
     T: Copy + Hash + Eq,
 {
-    IndexMap::from_iter(iter.into_iter().cloned().map(|k| (k, ())))
+    IndexMap::from_iter(iter.into_iter().copied().map(|k| (k, ())))
 }
 
 quickcheck! {
@@ -123,7 +123,7 @@ quickcheck! {
 
         // First see if `Vec::drain` is happy with this range.
         let result = std::panic::catch_unwind(|| {
-            let mut keys: Vec<u8> = map.keys().cloned().collect();
+            let mut keys: Vec<u8> = map.keys().copied().collect();
             keys.drain(range);
             keys
         });
@@ -155,7 +155,7 @@ quickcheck! {
         let mut iter = map.keys();
         for &key in insert.iter().unique() {
             if elements.contains(&key) {
-                assert_eq!(Some(key), iter.next().cloned());
+                assert_eq!(Some(&key), iter.next());
             }
         }
 
@@ -165,7 +165,7 @@ quickcheck! {
 
     fn indexing(insert: Vec<u8>) -> bool {
         let mut map: IndexMap<_, _> = insert.into_iter().map(|x| (x, x)).collect();
-        let set: IndexSet<_> = map.keys().cloned().collect();
+        let set: IndexSet<_> = map.keys().copied().collect();
         assert_eq!(map.len(), set.len());
 
         for (i, &key) in set.iter().enumerate() {
@@ -295,7 +295,7 @@ quickcheck! {
         let mut reference = HashMap::new();
         do_ops(&ops, &mut map, &mut reference);
         let mut visit = IndexMap::new();
-        let keys = Vec::from_iter(map.keys().cloned());
+        let keys = Vec::from_iter(map.keys().copied());
         for (k, v) in keys.iter().zip(map.values_mut()) {
             assert_eq!(&reference[k], v);
             assert!(!visit.contains_key(k));


### PR DESCRIPTION
`Copied` is available since Rust 1.36 and Rayon 1.2.