### PR TITLE
Simplify logic around `#[cfg(has_std)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,18 +77,13 @@
 //!
 //! [def]: map/struct.IndexMap.html#impl-Default
 
-#[cfg(not(has_std))]
 extern crate alloc;
 
 #[cfg(has_std)]
 #[macro_use]
 extern crate std;
 
-#[cfg(not(has_std))]
 use alloc::vec::{self, Vec};
-
-#[cfg(has_std)]
-use std::vec::{self, Vec};
 
 #[macro_use]
 mod macros;

--- a/src/rayon/mod.rs
+++ b/src/rayon/mod.rs
@@ -1,10 +1,6 @@
 use rayon::prelude::*;
 
-#[cfg(not(has_std))]
 use alloc::collections::LinkedList;
-
-#[cfg(has_std)]
-use std::collections::LinkedList;
 
 use crate::vec::Vec;
 


### PR DESCRIPTION
Unconditionally using `extern crate alloc;` allows removing several `#[cfg(has_std)]`/`#[cfg(not(has_std))]`.