### PR TITLE
Bump hashbrown to `0.11.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0", optional = true, default-features = false }
 rayon = { version = "1.2", optional = true }
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 default-features = false
 features = ["raw"]
 


### PR DESCRIPTION
This makes the dependency even to [hnsw](https://crates.io/crates/hnsw/0.7.0/dependencies) with hashbrown's latest release