### PR TITLE
Add IndexMap::into_{keys,values}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,9 @@ impl<K, V> Bucket<K, V> {
     fn key(self) -> K {
         self.key
     }
+    fn value(self) -> V {
+        self.value
+    }
     fn key_value(self) -> (K, V) {
         (self.key, self.value)
     }


### PR DESCRIPTION
This adds equivalents of the same methods of HashMap and BTreeMap stabilized in Rust 1.54.

- https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.into_keys
- https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.into_values
- https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.into_keys
- https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.into_values