### PR TITLE
Iterator polish

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -116,5 +116,9 @@ macro_rules! double_ended_iterator_methods {
         fn next_back(&mut self) -> Option<Self::Item> {
             self.iter.next_back().map($map_elt)
         }
+
+        fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+            self.iter.nth_back(n).map($map_elt)
+        }
     };
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -1122,6 +1122,13 @@ impl<K, V> ExactSizeIterator for Drain<'_, K, V> {
 
 impl<K, V> FusedIterator for Drain<'_, K, V> {}
 
+impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Drain<'_, K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let iter = self.iter.as_slice().iter().map(Bucket::refs);
+        f.debug_list().entries(iter).finish()
+    }
+}
+
 impl<'a, K, V, S> IntoIterator for &'a IndexMap<K, V, S> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;

--- a/src/map.rs
+++ b/src/map.rs
@@ -1057,6 +1057,8 @@ impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {
 
 impl<K, V> FusedIterator for IterMut<'_, K, V> {}
 
+// TODO: `impl Debug for IterMut` once we have MSRV 1.53 for `slice::IterMut::as_slice`
+
 /// An owning iterator over the entries of a `IndexMap`.
 ///
 /// This `struct` is created by the [`into_iter`] method on [`IndexMap`]

--- a/src/map.rs
+++ b/src/map.rs
@@ -948,6 +948,8 @@ impl<K, V> ExactSizeIterator for ValuesMut<'_, K, V> {
 
 impl<K, V> FusedIterator for ValuesMut<'_, K, V> {}
 
+// TODO: `impl Debug for ValuesMut` once we have MSRV 1.53 for `slice::IterMut::as_slice`
+
 /// An owning iterator over the values of a `IndexMap`.
 ///
 /// This `struct` is created by the [`into_values`] method on [`IndexMap`].

--- a/src/map.rs
+++ b/src/map.rs
@@ -1098,6 +1098,12 @@ impl<K, V> DoubleEndedIterator for Drain<'_, K, V> {
     double_ended_iterator_methods!(Bucket::key_value);
 }
 
+impl<K, V> ExactSizeIterator for Drain<'_, K, V> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
 impl<'a, K, V, S> IntoIterator for &'a IndexMap<K, V, S> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;

--- a/src/map.rs
+++ b/src/map.rs
@@ -813,9 +813,7 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
 }
 
 impl<K, V> DoubleEndedIterator for Keys<'_, K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Bucket::key_ref)
-    }
+    double_ended_iterator_methods!(Bucket::key_ref);
 }
 
 impl<K, V> ExactSizeIterator for Keys<'_, K, V> {
@@ -857,9 +855,7 @@ impl<K, V> Iterator for IntoKeys<K, V> {
 }
 
 impl<K, V> DoubleEndedIterator for IntoKeys<K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Bucket::key)
-    }
+    double_ended_iterator_methods!(Bucket::key);
 }
 
 impl<K, V> ExactSizeIterator for IntoKeys<K, V> {
@@ -893,9 +889,7 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
 }
 
 impl<K, V> DoubleEndedIterator for Values<'_, K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Bucket::value_ref)
-    }
+    double_ended_iterator_methods!(Bucket::value_ref);
 }
 
 impl<K, V> ExactSizeIterator for Values<'_, K, V> {
@@ -937,9 +931,7 @@ impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
 }
 
 impl<K, V> DoubleEndedIterator for ValuesMut<'_, K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Bucket::value_mut)
-    }
+    double_ended_iterator_methods!(Bucket::value_mut);
 }
 
 impl<K, V> ExactSizeIterator for ValuesMut<'_, K, V> {
@@ -966,9 +958,7 @@ impl<K, V> Iterator for IntoValues<K, V> {
 }
 
 impl<K, V> DoubleEndedIterator for IntoValues<K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Bucket::value)
-    }
+    double_ended_iterator_methods!(Bucket::value);
 }
 
 impl<K, V> ExactSizeIterator for IntoValues<K, V> {
@@ -1002,9 +992,7 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
 }
 
 impl<K, V> DoubleEndedIterator for Iter<'_, K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Bucket::refs)
-    }
+    double_ended_iterator_methods!(Bucket::refs);
 }
 
 impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
@@ -1046,9 +1034,7 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
 }
 
 impl<K, V> DoubleEndedIterator for IterMut<'_, K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Bucket::ref_mut)
-    }
+    double_ended_iterator_methods!(Bucket::ref_mut);
 }
 
 impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {
@@ -1075,9 +1061,7 @@ impl<K, V> Iterator for IntoIter<K, V> {
 }
 
 impl<K, V> DoubleEndedIterator for IntoIter<K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Bucket::key_value)
-    }
+    double_ended_iterator_methods!(Bucket::key_value);
 }
 
 impl<K, V> ExactSizeIterator for IntoIter<K, V> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -12,7 +12,7 @@ use crate::vec::{self, Vec};
 use ::core::cmp::Ordering;
 use ::core::fmt;
 use ::core::hash::{BuildHasher, Hash, Hasher};
-use ::core::iter::FromIterator;
+use ::core::iter::{FromIterator, FusedIterator};
 use ::core::ops::{Index, IndexMut, RangeBounds};
 use ::core::slice::{Iter as SliceIter, IterMut as SliceIterMut};
 
@@ -822,6 +822,8 @@ impl<K, V> ExactSizeIterator for Keys<'_, K, V> {
     }
 }
 
+impl<K, V> FusedIterator for Keys<'_, K, V> {}
+
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 impl<K, V> Clone for Keys<'_, K, V> {
     fn clone(&self) -> Self {
@@ -864,6 +866,8 @@ impl<K, V> ExactSizeIterator for IntoKeys<K, V> {
     }
 }
 
+impl<K, V> FusedIterator for IntoKeys<K, V> {}
+
 impl<K: fmt::Debug, V> fmt::Debug for IntoKeys<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let iter = self.iter.as_slice().iter().map(Bucket::key_ref);
@@ -897,6 +901,8 @@ impl<K, V> ExactSizeIterator for Values<'_, K, V> {
         self.iter.len()
     }
 }
+
+impl<K, V> FusedIterator for Values<'_, K, V> {}
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 impl<K, V> Clone for Values<'_, K, V> {
@@ -940,6 +946,8 @@ impl<K, V> ExactSizeIterator for ValuesMut<'_, K, V> {
     }
 }
 
+impl<K, V> FusedIterator for ValuesMut<'_, K, V> {}
+
 /// An owning iterator over the values of a `IndexMap`.
 ///
 /// This `struct` is created by the [`into_values`] method on [`IndexMap`].
@@ -966,6 +974,8 @@ impl<K, V> ExactSizeIterator for IntoValues<K, V> {
         self.iter.len()
     }
 }
+
+impl<K, V> FusedIterator for IntoValues<K, V> {}
 
 impl<K, V: fmt::Debug> fmt::Debug for IntoValues<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1000,6 +1010,8 @@ impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
         self.iter.len()
     }
 }
+
+impl<K, V> FusedIterator for Iter<'_, K, V> {}
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 impl<K, V> Clone for Iter<'_, K, V> {
@@ -1043,6 +1055,8 @@ impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {
     }
 }
 
+impl<K, V> FusedIterator for IterMut<'_, K, V> {}
+
 /// An owning iterator over the entries of a `IndexMap`.
 ///
 /// This `struct` is created by the [`into_iter`] method on [`IndexMap`]
@@ -1069,6 +1083,8 @@ impl<K, V> ExactSizeIterator for IntoIter<K, V> {
         self.iter.len()
     }
 }
+
+impl<K, V> FusedIterator for IntoIter<K, V> {}
 
 impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for IntoIter<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1103,6 +1119,8 @@ impl<K, V> ExactSizeIterator for Drain<'_, K, V> {
         self.iter.len()
     }
 }
+
+impl<K, V> FusedIterator for Drain<'_, K, V> {}
 
 impl<'a, K, V, S> IntoIterator for &'a IndexMap<K, V, S> {
     type Item = (&'a K, &'a V);

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -346,6 +346,13 @@ pub struct ParValuesMut<'a, K, V> {
     entries: &'a mut [Bucket<K, V>],
 }
 
+impl<K, V: fmt::Debug> fmt::Debug for ParValuesMut<'_, K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let iter = self.entries.iter().map(Bucket::value_ref);
+        f.debug_list().entries(iter).finish()
+    }
+}
+
 impl<'a, K: Send, V: Send> ParallelIterator for ParValuesMut<'a, K, V> {
     type Item = &'a mut V;
 

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -139,6 +139,13 @@ pub struct ParIterMut<'a, K, V> {
     entries: &'a mut [Bucket<K, V>],
 }
 
+impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for ParIterMut<'_, K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let iter = self.entries.iter().map(Bucket::refs);
+        f.debug_list().entries(iter).finish()
+    }
+}
+
 impl<'a, K: Sync + Send, V: Send> ParallelIterator for ParIterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -10,7 +10,7 @@ use crate::vec::{self, Vec};
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
-use core::iter::{Chain, FromIterator};
+use core::iter::{Chain, FromIterator, FusedIterator};
 use core::ops::{BitAnd, BitOr, BitXor, Index, RangeBounds, Sub};
 use core::slice;
 
@@ -717,6 +717,8 @@ impl<T> ExactSizeIterator for IntoIter<T> {
     }
 }
 
+impl<T> FusedIterator for IntoIter<T> {}
+
 impl<T: fmt::Debug> fmt::Debug for IntoIter<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let iter = self.iter.as_slice().iter().map(Bucket::key_ref);
@@ -750,6 +752,8 @@ impl<T> ExactSizeIterator for Iter<'_, T> {
         self.iter.len()
     }
 }
+
+impl<T> FusedIterator for Iter<'_, T> {}
 
 impl<T> Clone for Iter<'_, T> {
     fn clone(&self) -> Self {
@@ -791,6 +795,8 @@ impl<T> ExactSizeIterator for Drain<'_, T> {
         self.iter.len()
     }
 }
+
+impl<T> FusedIterator for Drain<'_, T> {}
 
 impl<'a, T, S> IntoIterator for &'a IndexSet<T, S> {
     type Item = &'a T;
@@ -959,6 +965,13 @@ where
     }
 }
 
+impl<T, S> FusedIterator for Difference<'_, T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+}
+
 impl<T, S> Clone for Difference<'_, T, S> {
     fn clone(&self) -> Self {
         Difference {
@@ -1024,6 +1037,13 @@ where
         }
         None
     }
+}
+
+impl<T, S> FusedIterator for Intersection<'_, T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
 }
 
 impl<T, S> Clone for Intersection<'_, T, S> {
@@ -1098,6 +1118,14 @@ where
     }
 }
 
+impl<T, S1, S2> FusedIterator for SymmetricDifference<'_, T, S1, S2>
+where
+    T: Eq + Hash,
+    S1: BuildHasher,
+    S2: BuildHasher,
+{
+}
+
 impl<T, S1, S2> Clone for SymmetricDifference<'_, T, S1, S2> {
     fn clone(&self) -> Self {
         SymmetricDifference {
@@ -1166,6 +1194,13 @@ where
     {
         self.iter.rfold(init, f)
     }
+}
+
+impl<T, S> FusedIterator for Union<'_, T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
 }
 
 impl<T, S> Clone for Union<'_, T, S> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -1083,6 +1083,13 @@ where
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()
     }
+
+    fn rfold<B, F>(self, init: B, f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.rfold(init, f)
+    }
 }
 
 impl<T, S1, S2> Clone for SymmetricDifference<'_, T, S1, S2> {
@@ -1145,6 +1152,13 @@ where
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()
+    }
+
+    fn rfold<B, F>(self, init: B, f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.rfold(init, f)
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -786,6 +786,12 @@ impl<T> DoubleEndedIterator for Drain<'_, T> {
     double_ended_iterator_methods!(Bucket::key);
 }
 
+impl<T> ExactSizeIterator for Drain<'_, T> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
 impl<'a, T, S> IntoIterator for &'a IndexSet<T, S> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;

--- a/src/set.rs
+++ b/src/set.rs
@@ -798,6 +798,13 @@ impl<T> ExactSizeIterator for Drain<'_, T> {
 
 impl<T> FusedIterator for Drain<'_, T> {}
 
+impl<T: fmt::Debug> fmt::Debug for Drain<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let iter = self.iter.as_slice().iter().map(Bucket::key_ref);
+        f.debug_list().entries(iter).finish()
+    }
+}
+
 impl<'a, T, S> IntoIterator for &'a IndexSet<T, S> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;

--- a/src/set.rs
+++ b/src/set.rs
@@ -708,9 +708,7 @@ impl<T> Iterator for IntoIter<T> {
 }
 
 impl<T> DoubleEndedIterator for IntoIter<T> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Bucket::key)
-    }
+    double_ended_iterator_methods!(Bucket::key);
 }
 
 impl<T> ExactSizeIterator for IntoIter<T> {
@@ -744,9 +742,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 }
 
 impl<T> DoubleEndedIterator for Iter<'_, T> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(Bucket::key_ref)
-    }
+    double_ended_iterator_methods!(Bucket::key_ref);
 }
 
 impl<T> ExactSizeIterator for Iter<'_, T> {


### PR DESCRIPTION
This is a variety of small improvements for the iterators:

- Use `double_ended_iterator_methods!`
- Specialize `nth_back` just like `nth`
- Add `rfold` for iterators built on `Chain`
- `impl ExactSizeIterator for Drain`
- `impl FusedIterator` for all serial iterators
- `impl Debug for Drain`, `ParIterMut`, and `ParValuesMut`
