### PR TITLE
Add `IndexMap::from(array)` and `IndexSet::from(array)`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,5 +4,6 @@ fn main() {
         Some(_) => autocfg::emit("has_std"),
         None => autocfg::new().emit_sysroot_crate("std"),
     }
+    autocfg::new().emit_rustc_version(1, 51);
     autocfg::rerun_path("build.rs");
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -1345,6 +1345,25 @@ where
     }
 }
 
+#[cfg(has_std)]
+impl<K, V, const N: usize> From<[(K, V); N]> for IndexMap<K, V, RandomState>
+where
+    K: Hash + Eq,
+{
+    /// # Examples
+    ///
+    /// ```
+    /// use indexmap::IndexMap;
+    ///
+    /// let map1 = IndexMap::from([(1, 2), (3, 4)]);
+    /// let map2: IndexMap<_, _> = [(1, 2), (3, 4)].into();
+    /// assert_eq!(map1, map2);
+    /// ```
+    fn from(arr: [(K, V); N]) -> Self {
+        std::array::IntoIter::new(arr).collect()
+    }
+}
+
 impl<K, V, S> Extend<(K, V)> for IndexMap<K, V, S>
 where
     K: Hash + Eq,
@@ -1838,5 +1857,15 @@ mod tests {
         assert!(values.contains(&'a'));
         assert!(values.contains(&'b'));
         assert!(values.contains(&'c'));
+    }
+
+    #[test]
+    fn from_array() {
+        let map = IndexMap::from([(1, 2), (3, 4)]);
+        let mut expected = IndexMap::new();
+        expected.insert(1, 2);
+        expected.insert(3, 4);
+
+        assert_eq!(map, expected)
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -1345,7 +1345,7 @@ where
     }
 }
 
-#[cfg(has_std)]
+#[cfg(all(has_std, rustc_1_51))]
 impl<K, V, const N: usize> From<[(K, V); N]> for IndexMap<K, V, RandomState>
 where
     K: Hash + Eq,
@@ -1860,6 +1860,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(has_std, rustc_1_51))]
     fn from_array() {
         let map = IndexMap::from([(1, 2), (3, 4)]);
         let mut expected = IndexMap::new();

--- a/src/set.rs
+++ b/src/set.rs
@@ -843,7 +843,7 @@ where
     }
 }
 
-#[cfg(has_std)]
+#[cfg(all(has_std, rustc_1_51))]
 impl<T, const N: usize> From<[T; N]> for IndexSet<T, RandomState>
 where
     T: Eq + Hash,
@@ -1731,6 +1731,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(has_std, rustc_1_51))]
     fn from_array() {
         let set1 = IndexSet::from([1, 2, 3, 4]);
         let set2: IndexSet<_> = [1, 2, 3, 4].into();

--- a/src/set.rs
+++ b/src/set.rs
@@ -843,6 +843,25 @@ where
     }
 }
 
+#[cfg(has_std)]
+impl<T, const N: usize> From<[T; N]> for IndexSet<T, RandomState>
+where
+    T: Eq + Hash,
+{
+    /// # Examples
+    ///
+    /// ```
+    /// use indexmap::IndexSet;
+    ///
+    /// let set1 = IndexSet::from([1, 2, 3, 4]);
+    /// let set2: IndexSet<_> = [1, 2, 3, 4].into();
+    /// assert_eq!(set1, set2);
+    /// ```
+    fn from(arr: [T; N]) -> Self {
+        std::array::IntoIter::new(arr).collect()
+    }
+}
+
 impl<T, S> Extend<T> for IndexSet<T, S>
 where
     T: Hash + Eq,
@@ -1709,5 +1728,13 @@ mod tests {
         assert_eq!(&set_d ^ &set_c, &set_a | &(&set_d - &set_b));
         assert_eq!(&set_c - &set_d, set_a);
         assert_eq!(&set_d - &set_c, &set_d - &set_b);
+    }
+
+    #[test]
+    fn from_array() {
+        let set1 = IndexSet::from([1, 2, 3, 4]);
+        let set2: IndexSet<_> = [1, 2, 3, 4].into();
+
+        assert_eq!(set1, set2);
     }
 }


### PR DESCRIPTION
This patch adds `IndexMap::from(array)` and `IndexSet::from(array)` to match the API for `HashMap`, `HashSet`, etc. as of https://github.com/rust-lang/rust/pull/84111.