### PR TITLE
Unify std and no_std APIs for `IndexMap` and `IndexSet`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,7 @@ rayon = { version = "1.2", optional = true }
 
 [dependencies.hashbrown]
 version = "0.11"
-default-features = false
-features = ["raw"]
+features = ["ahash", "raw"]
 
 [dev-dependencies]
 itertools = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,13 @@
 //! trigger this. It can be tested by building for a std-less target.
 //!
 //! - Creating maps and sets using [`new`][IndexMap::new] and
-//! [`with_capacity`][IndexMap::with_capacity] is unavailable without `std`.  
-//!   Use methods [`IndexMap::default`][def],
+//!   [`with_capacity`][IndexMap::with_capacity] are available without `std`;
+//!   they use [`hashbrown::hash_map::DefaultHashBuilder`] as their default 
+//!   hash builder.
+//!   You can also use methods [`IndexMap::default`][def],
 //!   [`with_hasher`][IndexMap::with_hasher],
-//!   [`with_capacity_and_hasher`][IndexMap::with_capacity_and_hasher] instead.
-//!   A no-std compatible hasher will be needed as well, for example
+//!   [`with_capacity_and_hasher`][IndexMap::with_capacity_and_hasher],
+//!   optionally with other no_std-compatible hashers, for example
 //!   from the crate `twox-hash`.
 //! - Macros [`indexmap!`] and [`indexset!`] are unavailable without `std`.
 //!

--- a/src/map.rs
+++ b/src/map.rs
@@ -18,6 +18,8 @@ use ::core::slice::{Iter as SliceIter, IterMut as SliceIterMut};
 
 #[cfg(has_std)]
 use std::collections::hash_map::RandomState;
+#[cfg(not(has_std))]
+use hashbrown::hash_map::DefaultHashBuilder;
 
 use self::core::IndexMapCore;
 use crate::equivalent::Equivalent;
@@ -73,7 +75,7 @@ pub struct IndexMap<K, V, S = RandomState> {
     hash_builder: S,
 }
 #[cfg(not(has_std))]
-pub struct IndexMap<K, V, S> {
+pub struct IndexMap<K, V, S = DefaultHashBuilder> {
     core: IndexMapCore<K, V>,
     hash_builder: S,
 }
@@ -140,7 +142,6 @@ where
     }
 }
 
-#[cfg(has_std)]
 impl<K, V> IndexMap<K, V> {
     /// Create a new map. (Does not allocate.)
     #[inline]

--- a/src/set.rs
+++ b/src/set.rs
@@ -5,6 +5,8 @@ pub use crate::rayon::set as rayon;
 
 #[cfg(has_std)]
 use std::collections::hash_map::RandomState;
+#[cfg(not(has_std))]
+use hashbrown::hash_map::DefaultHashBuilder;
 
 use crate::vec::{self, Vec};
 use core::cmp::Ordering;
@@ -64,7 +66,7 @@ pub struct IndexSet<T, S = RandomState> {
     map: IndexMap<T, (), S>,
 }
 #[cfg(not(has_std))]
-pub struct IndexSet<T, S> {
+pub struct IndexSet<T, S = DefaultHashBuilder> {
     map: IndexMap<T, (), S>,
 }
 
@@ -124,7 +126,6 @@ where
     }
 }
 
-#[cfg(has_std)]
 impl<T> IndexSet<T> {
     /// Create a new set. (Does not allocate.)
     pub fn new() -> Self {


### PR DESCRIPTION
Both `IndexMap` and `IndexSet` restrict access to their `new()` and `with_capacity()` methods behind the `has_std` feature gate.
Turns out, this isn't actually required because we can use `DefaultHashBuilder` from the `hashbrown` crate for the default value of the `S: BuildHasher` type parameter.

This unifies the API for downstream users of this crate that also support both std and no_std environments, which significantly improves ergonomics and simplifies code.
I have also modified the documentation to reflect these changes.

**Note:** I believe we could also remove the `#[cfg(has_std)]` restriction on the two macros `indexmap!()` and `indexset!()`, but I didn't include those changes here yet. I can add them for consistency's sake, if you'd like.
