### PR TITLE
Clarify docs for `.pop()`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -636,6 +636,8 @@ where
 
     /// Remove the last key-value pair
     ///
+    /// This preserves the order of the remaining elements.
+    ///
     /// Computes in **O(1)** time (average).
     pub fn pop(&mut self) -> Option<(K, V)> {
         self.core.pop()

--- a/src/set.rs
+++ b/src/set.rs
@@ -532,6 +532,8 @@ where
 
     /// Remove the last value
     ///
+    /// This preserves the order of the remaining elements.
+    ///
     /// Computes in **O(1)** time (average).
     pub fn pop(&mut self) -> Option<T> {
         self.map.pop().map(|(x, ())| x)


### PR DESCRIPTION
Most other methods specify how they affect insertion order; this PR adds those notes to `.pop()` as well.