### PR TITLE
Add miri builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,18 @@ jobs:
           components: clippy
       - run: cargo clippy
 
+  miri:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: miri
+      - run: cargo miri test

--- a/src/map.rs
+++ b/src/map.rs
@@ -1567,7 +1567,7 @@ mod tests {
 
         let mut keys = vec![];
         keys.extend(0..16);
-        keys.extend(128..267);
+        keys.extend(if cfg!(miri) { 32..64 } else { 128..267 });
 
         for &i in &keys {
             let old_map = map.clone();

--- a/src/set.rs
+++ b/src/set.rs
@@ -1426,7 +1426,7 @@ mod tests {
 
         let mut values = vec![];
         values.extend(0..16);
-        values.extend(128..267);
+        values.extend(if cfg!(miri) { 32..64 } else { 128..267 });
 
         for &i in &values {
             let old_set = set.clone();


### PR DESCRIPTION
This adds a builder to run `cargo miri` in order to check for certain classes of undefined behavior.