### PR TITLE
Add a `replace_full` method on `IndexSet`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indexmap"
 edition = "2018"
-version = "1.8.0"
+version = "1.8.1"
 authors = [
 "bluss",
 "Josh Stone <cuviper@gmail.com>"

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,3 +1,10 @@
+- 1.8.1
+
+  - The new ``IndexSet::replace_full`` will return the index of the item along
+    with the replaced value, if any, by @zakcutner in PR 222_.
+
+.. _222: https://github.com/bluss/indexmap/pull/222
+
 - 1.8.0
 
   - The new ``IndexMap::into_keys`` and ``IndexMap::into_values`` will consume


### PR DESCRIPTION
* Add a new `replace_full` method, which behaves like `replace` but also
  returns the index of the item.

* Clarify that `replace` and `replace_all` do not modify the replaced
  item's insertion order in the documentation.

* Add test coverage for `replace` and `replace_full` by copying the
  existing tests for `insert` and `insert_full`.

Closes #221 