### PR TITLE
Use first-class patterns for split_first/last

### DIFF
--- a/src/map/core.rs
+++ b/src/map/core.rs
@@ -204,7 +204,8 @@ impl<K, V> IndexMapCore<K, V> {
 
     /// Shrink the capacity of the map with a lower bound
     pub(crate) fn shrink_to(&mut self, min_capacity: usize) {
-        self.indices.shrink_to(min_capacity, get_hash(&self.entries));
+        self.indices
+            .shrink_to(min_capacity, get_hash(&self.entries));
         self.entries.shrink_to(min_capacity);
     }
 

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -130,7 +130,7 @@ impl<K, V> Slice<K, V> {
     /// Returns the first key-value pair and the rest of the slice,
     /// or `None` if it is empty.
     pub fn split_first(&self) -> Option<((&K, &V), &Self)> {
-        if let Some((first, rest)) = self.entries.split_first() {
+        if let [first, rest @ ..] = &self.entries {
             Some((first.refs(), Self::from_slice(rest)))
         } else {
             None
@@ -140,7 +140,7 @@ impl<K, V> Slice<K, V> {
     /// Returns the first key-value pair and the rest of the slice,
     /// with mutable access to the value, or `None` if it is empty.
     pub fn split_first_mut(&mut self) -> Option<((&K, &mut V), &mut Self)> {
-        if let Some((first, rest)) = self.entries.split_first_mut() {
+        if let [first, rest @ ..] = &mut self.entries {
             Some((first.ref_mut(), Self::from_mut_slice(rest)))
         } else {
             None
@@ -150,7 +150,7 @@ impl<K, V> Slice<K, V> {
     /// Returns the last key-value pair and the rest of the slice,
     /// or `None` if it is empty.
     pub fn split_last(&self) -> Option<((&K, &V), &Self)> {
-        if let Some((last, rest)) = self.entries.split_last() {
+        if let [rest @ .., last] = &self.entries {
             Some((last.refs(), Self::from_slice(rest)))
         } else {
             None
@@ -160,7 +160,7 @@ impl<K, V> Slice<K, V> {
     /// Returns the last key-value pair and the rest of the slice,
     /// with mutable access to the value, or `None` if it is empty.
     pub fn split_last_mut(&mut self) -> Option<((&K, &mut V), &mut Self)> {
-        if let Some((last, rest)) = self.entries.split_last_mut() {
+        if let [rest @ .., last] = &mut self.entries {
             Some((last.ref_mut(), Self::from_mut_slice(rest)))
         } else {
             None

--- a/src/serde_seq.rs
+++ b/src/serde_seq.rs
@@ -34,7 +34,7 @@ use crate::IndexMap;
 /// Serializes a `map::Slice` as an ordered sequence.
 ///
 /// This behaves like [`crate::serde_seq`] for `IndexMap`, serializing a sequence
-/// of `(key, value)` pairs, rather than as a map that might not preserver order.
+/// of `(key, value)` pairs, rather than as a map that might not preserve order.
 ///
 /// Requires crate feature `"serde"` or `"serde-1"`
 impl<K, V> Serialize for MapSlice<K, V>

--- a/src/serde_seq.rs
+++ b/src/serde_seq.rs
@@ -36,7 +36,7 @@ use crate::IndexMap;
 /// This behaves like [`crate::serde_seq`] for `IndexMap`, serializing a sequence
 /// of `(key, value)` pairs, rather than as a map that might not preserve order.
 ///
-/// Requires crate feature `"serde"` or `"serde-1"`
+/// Requires crate feature `"serde"`
 impl<K, V> Serialize for MapSlice<K, V>
 where
     K: Serialize,
@@ -52,7 +52,7 @@ where
 
 /// Serializes a `set::Slice` as an ordered sequence.
 ///
-/// Requires crate feature `"serde"` or `"serde-1"`
+/// Requires crate feature `"serde"`
 impl<T> Serialize for SetSlice<T>
 where
     T: Serialize,

--- a/src/serde_seq.rs
+++ b/src/serde_seq.rs
@@ -27,9 +27,9 @@ use core::fmt::{self, Formatter};
 use core::hash::{BuildHasher, Hash};
 use core::marker::PhantomData;
 
-use crate::IndexMap;
 use crate::map::Slice as MapSlice;
 use crate::set::Slice as SetSlice;
+use crate::IndexMap;
 
 /// Serializes a `map::Slice` as an ordered sequence.
 ///

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -88,7 +88,7 @@ impl<T> Slice<T> {
     /// Returns the first value and the rest of the slice,
     /// or `None` if it is empty.
     pub fn split_first(&self) -> Option<(&T, &Self)> {
-        if let Some((first, rest)) = self.entries.split_first() {
+        if let [first, rest @ ..] = &self.entries {
             Some((&first.key, Self::from_slice(rest)))
         } else {
             None
@@ -98,7 +98,7 @@ impl<T> Slice<T> {
     /// Returns the last value and the rest of the slice,
     /// or `None` if it is empty.
     pub fn split_last(&self) -> Option<(&T, &Self)> {
-        if let Some((last, rest)) = self.entries.split_last() {
+        if let [rest @ .., last] = &self.entries {
             Some((&last.key, Self::from_slice(rest)))
         } else {
             None


### PR DESCRIPTION
Just a small improvement for fun, plus a few other small fixes.