### PR TITLE
Allow compiling on 1.56.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.56.1 # MSRV
+          - rust: 1.56.0 # MSRV
             features:
           - rust: stable
             features: serde
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.56.1
+          - rust: 1.56.0
             target: thumbv6m-none-eabi
           - rust: stable
             target: thumbv6m-none-eabi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.56.0 # MSRV
+          - rust: 1.56.1 # MSRV
             features:
           - rust: stable
             features: serde
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.56.0
+          - rust: 1.56.1
             target: thumbv6m-none-eabi
           - rust: stable
             target: thumbv6m-none-eabi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR MIT"
 description = "A hash table with consistent order and fast iteration."
 keywords = ["hashmap", "no_std"]
 categories = ["data-structures", "no-std"]
-rust-version = "1.56.1"
+rust-version = "1.56"
 
 [lib]
 bench = false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build status](https://github.com/bluss/indexmap/workflows/Continuous%20integration/badge.svg?branch=master)](https://github.com/bluss/indexmap/actions)
 [![crates.io](https://img.shields.io/crates/v/indexmap.svg)](https://crates.io/crates/indexmap)
 [![docs](https://docs.rs/indexmap/badge.svg)](https://docs.rs/indexmap)
-[![rustc](https://img.shields.io/badge/rust-1.56.1%2B-orange.svg)](https://img.shields.io/badge/rust-1.56.1%2B-orange.svg)
+[![rustc](https://img.shields.io/badge/rust-1.56%2B-orange.svg)](https://img.shields.io/badge/rust-1.56%2B-orange.svg)
 
 A pure-Rust hash table which preserves (in a limited sense) insertion order.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! ### Rust Version
 //!
-//! This version of indexmap requires Rust 1.56.1 or later.
+//! This version of indexmap requires Rust 1.56 or later.
 //!
 //! The indexmap 2.x release series will use a carefully considered version
 //! upgrade policy, where in a later 2.x version, we will raise the minimum


### PR DESCRIPTION
This reverts commit 8a571c6d68cb38c283d563ff6972613e0eea4111.

See https://github.com/rust-lang/hashbrown/pull/343.