### PR TITLE
impl Arbitrary for IndexMap and IndexSet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,15 @@ jobs:
           - rust: 1.61.0 # MSRV
             features:
           - rust: stable
-            features: serde
+            features: arbitrary
+          - rust: stable
+            features: quickcheck
           - rust: stable
             features: rayon
           - rust: stable
             features: rustc-rayon
+          - rust: stable
+            features: serde
           - rust: stable
             features: std
           - rust: beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ rust-version = "1.61"
 bench = false
 
 [dependencies]
+arbitrary = { version = "1.0", optional = true, default-features = false }
+quickcheck = { version = "1.0", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 rayon = { version = "1.4.1", optional = true }
 
@@ -51,7 +53,7 @@ no-dev-version = true
 tag-name = "{{version}}"
 
 [package.metadata.docs.rs]
-features = ["serde", "rayon"]
+features = ["arbitrary", "quickcheck", "serde", "rayon"]
 
 [workspace]
 members = ["test-nostd", "test-serde"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,6 +17,9 @@
     comparison traits like `Eq` only consider items in order, rather than hash
     lookups, and slices even implement `Hash`.
 
+  - `IndexMap` and `IndexSet` both implement `arbitrary::Arbitrary<'_>` and
+    `quickcheck::Arbitrary` if those optional dependency features are enabled.
+
   - The `hashbrown` dependency has been updated to version 0.13.
 
 - 1.9.1

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,0 +1,75 @@
+#[cfg(feature = "arbitrary")]
+mod impl_arbitrary {
+    use crate::{IndexMap, IndexSet};
+    use arbitrary::{Arbitrary, Result, Unstructured};
+    use core::hash::{BuildHasher, Hash};
+
+    impl<'a, K, V, S> Arbitrary<'a> for IndexMap<K, V, S>
+    where
+        K: Arbitrary<'a> + Hash + Eq,
+        V: Arbitrary<'a>,
+        S: BuildHasher + Default,
+    {
+        fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+            u.arbitrary_iter()?.collect()
+        }
+
+        fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
+            u.arbitrary_take_rest_iter()?.collect()
+        }
+    }
+
+    impl<'a, T, S> Arbitrary<'a> for IndexSet<T, S>
+    where
+        T: Arbitrary<'a> + Hash + Eq,
+        S: BuildHasher + Default,
+    {
+        fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+            u.arbitrary_iter()?.collect()
+        }
+
+        fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
+            u.arbitrary_take_rest_iter()?.collect()
+        }
+    }
+}
+
+#[cfg(feature = "quickcheck")]
+mod impl_quickcheck {
+    use crate::{IndexMap, IndexSet};
+    use alloc::boxed::Box;
+    use alloc::vec::Vec;
+    use core::hash::{BuildHasher, Hash};
+    use quickcheck::{Arbitrary, Gen};
+
+    impl<K, V, S> Arbitrary for IndexMap<K, V, S>
+    where
+        K: Arbitrary + Hash + Eq,
+        V: Arbitrary,
+        S: BuildHasher + Default + Clone + 'static,
+    {
+        fn arbitrary(g: &mut Gen) -> Self {
+            Self::from_iter(Vec::arbitrary(g))
+        }
+
+        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+            let vec = Vec::from_iter(self.clone());
+            Box::new(vec.shrink().map(Self::from_iter))
+        }
+    }
+
+    impl<T, S> Arbitrary for IndexSet<T, S>
+    where
+        T: Arbitrary + Hash + Eq,
+        S: BuildHasher + Default + Clone + 'static,
+    {
+        fn arbitrary(g: &mut Gen) -> Self {
+            Self::from_iter(Vec::arbitrary(g))
+        }
+
+        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+            let vec = Vec::from_iter(self.clone());
+            Box::new(vec.shrink().map(Self::from_iter))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ extern crate std;
 
 use alloc::vec::{self, Vec};
 
+mod arbitrary;
 #[macro_use]
 mod macros;
 mod equivalent;


### PR DESCRIPTION
This implements both `arbitrary::Arbitrary` and `quickcheck::Arbitrary`
behind optional dependencies on their respective crates.
