### PR TITLE
Add `iter_mut` for `IndexSet`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,9 @@ impl<K, V> Bucket<K, V> {
     fn key_ref(&self) -> &K {
         &self.key
     }
+    fn key_mut(&mut self) -> &mut K {
+        &mut self.key
+    }
     fn value_ref(&self) -> &V {
         &self.value
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -6,7 +6,7 @@ mod slice;
 #[cfg(test)]
 mod tests;
 
-pub use self::iter::{Difference, Drain, Intersection, IntoIter, Iter, SymmetricDifference, Union};
+pub use self::iter::{Difference, Drain, Intersection, IntoIter, Iter, IterMut, SymmetricDifference, Union};
 pub use self::slice::Slice;
 
 #[cfg(feature = "rayon")]
@@ -202,6 +202,11 @@ impl<T, S> IndexSet<T, S> {
     /// Return an iterator over the values of the set, in their order
     pub fn iter(&self) -> Iter<'_, T> {
         Iter::new(self.as_entries())
+    }
+
+    /// Return a mutable iterator over the values of the set, in their order
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+        IterMut::new( self.as_entries_mut())
     }
 
     /// Remove all elements in the set, while preserving its capacity.


### PR DESCRIPTION
This patch adds iter_mut method for IndexSet to match the API for HashSet **for 2.0**