### PR TITLE
Add more slicing methods to iterators, like std

### DIFF
--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -108,6 +108,11 @@ impl<'a, K, V> IterMut<'a, K, V> {
     }
 
     /// Returns a slice of the remaining entries in the iterator.
+    pub fn as_slice(&self) -> &Slice<K, V> {
+        Slice::from_slice(self.iter.as_slice())
+    }
+
+    /// Returns a mutable slice of the remaining entries in the iterator.
     ///
     /// To avoid creating `&mut` references that alias, this is forced to consume the iterator.
     pub fn into_slice(self) -> &'a mut Slice<K, V> {
@@ -157,6 +162,16 @@ impl<K, V> IntoIter<K, V> {
             iter: entries.into_iter(),
         }
     }
+
+    /// Returns a slice of the remaining entries in the iterator.
+    pub fn as_slice(&self) -> &Slice<K, V> {
+        Slice::from_slice(self.iter.as_slice())
+    }
+
+    /// Returns a mutable slice of the remaining entries in the iterator.
+    pub fn as_mut_slice(&mut self) -> &mut Slice<K, V> {
+        Slice::from_mut_slice(self.iter.as_mut_slice())
+    }
 }
 
 impl<K, V> Iterator for IntoIter<K, V> {
@@ -198,6 +213,11 @@ pub struct Drain<'a, K, V> {
 impl<'a, K, V> Drain<'a, K, V> {
     pub(super) fn new(iter: vec::Drain<'a, Bucket<K, V>>) -> Self {
         Self { iter }
+    }
+
+    /// Returns a slice of the remaining entries in the iterator.
+    pub fn as_slice(&self) -> &Slice<K, V> {
+        Slice::from_slice(self.iter.as_slice())
     }
 }
 

--- a/src/set/iter.rs
+++ b/src/set/iter.rs
@@ -97,6 +97,11 @@ impl<T> IntoIter<T> {
             iter: entries.into_iter(),
         }
     }
+
+    /// Returns a slice of the remaining entries in the iterator.
+    pub fn as_slice(&self) -> &Slice<T> {
+        Slice::from_slice(self.iter.as_slice())
+    }
 }
 
 impl<T> Iterator for IntoIter<T> {
@@ -138,6 +143,11 @@ pub struct Drain<'a, T> {
 impl<'a, T> Drain<'a, T> {
     pub(super) fn new(iter: vec::Drain<'a, Bucket<T>>) -> Self {
         Self { iter }
+    }
+
+    /// Returns a slice of the remaining entries in the iterator.
+    pub fn as_slice(&self) -> &Slice<T> {
+        Slice::from_slice(self.iter.as_slice())
     }
 }
 


### PR DESCRIPTION
In fact, these are directly relying on the same methods from `std`
iterators, since we build our iterators as simple wrappers on those.
