### PR TITLE
Improve feature flag documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ no-dev-version = true
 tag-name = "{{version}}"
 
 [package.metadata.docs.rs]
-all-features = true
+all-features = ["arbitrary", "quickcheck", "serde", "rayon"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ no-dev-version = true
 tag-name = "{{version}}"
 
 [package.metadata.docs.rs]
-all-features = ["arbitrary", "quickcheck", "serde", "rayon"]
+features = ["arbitrary", "quickcheck", "serde", "rayon"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,8 @@ no-dev-version = true
 tag-name = "{{version}}"
 
 [package.metadata.docs.rs]
-features = ["arbitrary", "quickcheck", "serde", "rayon"]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]
 members = ["test-nostd", "test-serde"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -28,6 +28,9 @@
 
   - The `hashbrown` dependency has been updated to version 0.13.
 
+  - The `serde_seq` module has been moved from the crate root to below the
+    `map` module.
+
 - 1.9.2
 
   - `IndexMap` and `IndexSet` both implement `arbitrary::Arbitrary<'_>` and

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "arbitrary")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arbitrary")))]
 mod impl_arbitrary {
     use crate::{IndexMap, IndexSet};
     use arbitrary::{Arbitrary, Result, Unstructured};
@@ -35,6 +36,7 @@ mod impl_arbitrary {
 }
 
 #[cfg(feature = "quickcheck")]
+#[cfg_attr(docsrs, doc(cfg(feature = "quickcheck")))]
 mod impl_quickcheck {
     use crate::{IndexMap, IndexSet};
     use alloc::boxed::Box;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,9 +116,6 @@ mod mutable_keys;
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 mod serde;
-#[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-pub mod serde_seq;
 mod util;
 
 pub mod map;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! [`IndexSet`]: set/struct.IndexSet.html
 //!
 //!
-//! ### Feature Highlights
+//! ### Highlights
 //!
 //! [`IndexMap`] and [`IndexSet`] are drop-in compatible with the std `HashMap`
 //! and `HashSet`, but they also have some features of note:
@@ -25,6 +25,28 @@
 //!   between borrowed and owned versions of keys.
 //! - The [`MutableKeys`][map::MutableKeys] trait, which gives opt-in mutable
 //!   access to hash map keys.
+//!
+//! ### Feature Flags
+//!
+//! To reduce the amount of compiled code in the crate by default, certain
+//! features are gated behind [feature flags]. These allow you to opt in to (or
+//! out of) functionality. Below is a list of the features available in this
+//! crate.
+//!
+//! * `std`: Enables features which require the Rust standard library. For more
+//!   information see the section on [`no_std`].
+//! * `rayon`: Enables parallel iteration and other parallel methods.
+//! * `serde`: Adds implementations for [`Serialize`] and [`Deserialize`]
+//!   to [`IndexMap`] and [`IndexSet`]. Alternative implementations for
+//!   (de)serializing [`IndexMap`] as an ordered sequence are available in the
+//!   [`serde_seq`] module.
+//!
+//! _Note: only the `std` feature is enabled by default._
+//!
+//! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
+//! [`no_std`]: #no-standard-library-targets
+//! [`Serialize`]: `::serde::Serialize`
+//! [`Deserialize`]: `::serde::Deserialize`
 //!
 //! ### Alternate Hashers
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ mod macros;
 mod equivalent;
 mod mutable_keys;
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 mod serde;
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
@@ -126,6 +127,7 @@ pub mod set;
 // Placed after `map` and `set` so new `rayon` methods on the types
 // are documented after the "normal" methods.
 #[cfg(feature = "rayon")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 mod rayon;
 
 #[cfg(feature = "rustc-rayon")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,10 @@
 //!   to [`IndexMap`] and [`IndexSet`]. Alternative implementations for
 //!   (de)serializing [`IndexMap`] as an ordered sequence are available in the
 //!   [`map::serde_seq`] module.
+//! * `arbitrary`: Adds implementations for the [`arbitrary::Arbitrary`] trait
+//!   to [`IndexMap`] and [`IndexSet`].
+//! * `quickcheck`: Adds implementations for the [`quickcheck::Arbitrary`] trait
+//!   to [`IndexMap`] and [`IndexSet`].
 //!
 //! _Note: only the `std` feature is enabled by default._
 //!
@@ -47,6 +51,8 @@
 //! [`no_std`]: #no-standard-library-targets
 //! [`Serialize`]: `::serde::Serialize`
 //! [`Deserialize`]: `::serde::Deserialize`
+//! [`arbitrary::Arbitrary`]: `::arbitrary::Arbitrary`
+//! [`quickcheck::Arbitrary`]: `::quickcheck::Arbitrary`
 //!
 //! ### Alternate Hashers
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@
 //!
 //! [def]: map/struct.IndexMap.html#impl-Default
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 extern crate alloc;
 
 #[cfg(feature = "std")]
@@ -92,6 +94,7 @@ mod mutable_keys;
 #[cfg(feature = "serde")]
 mod serde;
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde_seq;
 mod util;
 
@@ -245,4 +248,5 @@ impl core::fmt::Display for TryReserveError {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for TryReserveError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! * `serde`: Adds implementations for [`Serialize`] and [`Deserialize`]
 //!   to [`IndexMap`] and [`IndexSet`]. Alternative implementations for
 //!   (de)serializing [`IndexMap`] as an ordered sequence are available in the
-//!   [`serde_seq`] module.
+//!   [`map::serde_seq`] module.
 //!
 //! _Note: only the `std` feature is enabled by default._
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[macro_export]
 /// Create an `IndexMap` from a list of key-value pairs
 ///
@@ -35,6 +36,7 @@ macro_rules! indexmap {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[macro_export]
 /// Create an `IndexSet` from a list of values
 ///

--- a/src/map.rs
+++ b/src/map.rs
@@ -1118,7 +1118,6 @@ where
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-
 impl<K, V, const N: usize> From<[(K, V); N]> for IndexMap<K, V, RandomState>
 where
     K: Hash + Eq,

--- a/src/map.rs
+++ b/src/map.rs
@@ -5,6 +5,10 @@ mod core;
 mod iter;
 mod slice;
 
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+pub mod serde_seq;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -148,6 +148,7 @@ where
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<K, V> IndexMap<K, V> {
     /// Create a new map. (Does not allocate.)
     #[inline]
@@ -1112,6 +1113,8 @@ where
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+
 impl<K, V, const N: usize> From<[(K, V); N]> for IndexMap<K, V, RandomState>
 where
     K: Hash + Eq,

--- a/src/map/serde_seq.rs
+++ b/src/map/serde_seq.rs
@@ -12,7 +12,7 @@
 //! # use serde_derive::{Deserialize, Serialize};
 //! #[derive(Deserialize, Serialize)]
 //! struct Data {
-//!     #[serde(with = "indexmap::serde_seq")]
+//!     #[serde(with = "indexmap::map::serde_seq")]
 //!     map: IndexMap<i32, u64>,
 //!     // ...
 //! }
@@ -68,7 +68,7 @@ where
 /// # use serde_derive::Serialize;
 /// #[derive(Serialize)]
 /// struct Data {
-///     #[serde(serialize_with = "indexmap::serde_seq::serialize")]
+///     #[serde(serialize_with = "indexmap::map::serde_seq::serialize")]
 ///     map: IndexMap<i32, u64>,
 ///     // ...
 /// }
@@ -122,7 +122,7 @@ where
 /// # use serde_derive::Deserialize;
 /// #[derive(Deserialize)]
 /// struct Data {
-///     #[serde(deserialize_with = "indexmap::serde_seq::deserialize")]
+///     #[serde(deserialize_with = "indexmap::map::serde_seq::deserialize")]
 ///     map: IndexMap<i32, u64>,
 ///     // ...
 /// }

--- a/src/map/serde_seq.rs
+++ b/src/map/serde_seq.rs
@@ -31,7 +31,7 @@ use crate::IndexMap;
 
 /// Serializes a `map::Slice` as an ordered sequence.
 ///
-/// This behaves like [`crate::serde_seq`] for `IndexMap`, serializing a sequence
+/// This behaves like [`crate::map::serde_seq`] for `IndexMap`, serializing a sequence
 /// of `(key, value)` pairs, rather than as a map that might not preserve order.
 impl<K, V> Serialize for MapSlice<K, V>
 where

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -2,8 +2,8 @@
 //!
 //! You will rarely need to interact with this module directly unless you need to name one of the
 //! iterator types.
-//!
-//! Requires crate feature `"rayon"`
+
+#![cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 
 use super::collect;
 use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
@@ -21,7 +21,6 @@ use crate::Bucket;
 use crate::Entries;
 use crate::IndexMap;
 
-/// Requires crate feature `"rayon"`.
 impl<K, V, S> IntoParallelIterator for IndexMap<K, V, S>
 where
     K: Send,
@@ -37,7 +36,6 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
 impl<K, V> IntoParallelIterator for Box<Slice<K, V>>
 where
     K: Send,
@@ -81,7 +79,6 @@ impl<K: Send, V: Send> IndexedParallelIterator for IntoParIter<K, V> {
     indexed_parallel_iterator_methods!(Bucket::key_value);
 }
 
-/// Requires crate feature `"rayon"`.
 impl<'a, K, V, S> IntoParallelIterator for &'a IndexMap<K, V, S>
 where
     K: Sync,
@@ -97,7 +94,6 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
 impl<'a, K, V> IntoParallelIterator for &'a Slice<K, V>
 where
     K: Sync,
@@ -147,7 +143,6 @@ impl<K: Sync, V: Sync> IndexedParallelIterator for ParIter<'_, K, V> {
     indexed_parallel_iterator_methods!(Bucket::refs);
 }
 
-/// Requires crate feature `"rayon"`.
 impl<'a, K, V, S> IntoParallelIterator for &'a mut IndexMap<K, V, S>
 where
     K: Sync + Send,
@@ -163,7 +158,6 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
 impl<'a, K, V> IntoParallelIterator for &'a mut Slice<K, V>
 where
     K: Sync + Send,
@@ -207,7 +201,6 @@ impl<K: Sync + Send, V: Send> IndexedParallelIterator for ParIterMut<'_, K, V> {
     indexed_parallel_iterator_methods!(Bucket::ref_mut);
 }
 
-/// Requires crate feature `"rayon"`.
 impl<'a, K, V, S> ParallelDrainRange<usize> for &'a mut IndexMap<K, V, S>
 where
     K: Send,
@@ -395,7 +388,6 @@ impl<K: Sync, V: Sync> IndexedParallelIterator for ParValues<'_, K, V> {
     indexed_parallel_iterator_methods!(Bucket::value_ref);
 }
 
-/// Requires crate feature `"rayon"`.
 impl<K, V, S> IndexMap<K, V, S>
 where
     K: Send,
@@ -412,7 +404,6 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
 impl<K, V> Slice<K, V>
 where
     K: Send,
@@ -546,7 +537,6 @@ impl<K: Send, V: Send> IndexedParallelIterator for ParValuesMut<'_, K, V> {
     indexed_parallel_iterator_methods!(Bucket::value_mut);
 }
 
-/// Requires crate feature `"rayon"`.
 impl<K, V, S> FromParallelIterator<(K, V)> for IndexMap<K, V, S>
 where
     K: Eq + Hash + Send,
@@ -567,7 +557,6 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
 impl<K, V, S> ParallelExtend<(K, V)> for IndexMap<K, V, S>
 where
     K: Eq + Hash + Send,
@@ -584,7 +573,6 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
 impl<'a, K: 'a, V: 'a, S> ParallelExtend<(&'a K, &'a V)> for IndexMap<K, V, S>
 where
     K: Copy + Eq + Hash + Send + Sync,

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -3,8 +3,6 @@
 //! You will rarely need to interact with this module directly unless you need to name one of the
 //! iterator types.
 
-#![cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
-
 use super::collect;
 use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
 use rayon::prelude::*;

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -3,8 +3,6 @@
 //! You will rarely need to interact with this module directly unless you need to name one of the
 //! iterator types.
 
-#![cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
-
 use super::collect;
 use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
 use rayon::prelude::*;
@@ -22,7 +20,6 @@ use crate::IndexSet;
 
 type Bucket<T> = crate::Bucket<T, ()>;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<T, S> IntoParallelIterator for IndexSet<T, S>
 where
     T: Send,
@@ -37,7 +34,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<T> IntoParallelIterator for Box<Slice<T>>
 where
     T: Send,
@@ -80,7 +76,6 @@ impl<T: Send> IndexedParallelIterator for IntoParIter<T> {
     indexed_parallel_iterator_methods!(Bucket::key);
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<'a, T, S> IntoParallelIterator for &'a IndexSet<T, S>
 where
     T: Sync,
@@ -95,7 +90,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<'a, T> IntoParallelIterator for &'a Slice<T>
 where
     T: Sync,
@@ -144,7 +138,6 @@ impl<T: Sync> IndexedParallelIterator for ParIter<'_, T> {
     indexed_parallel_iterator_methods!(Bucket::key_ref);
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<'a, T, S> ParallelDrainRange<usize> for &'a mut IndexSet<T, S>
 where
     T: Send,
@@ -585,7 +578,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<T, S> FromParallelIterator<T> for IndexSet<T, S>
 where
     T: Eq + Hash + Send,
@@ -605,7 +597,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<T, S> ParallelExtend<T> for IndexSet<T, S>
 where
     T: Eq + Hash + Send,
@@ -621,7 +612,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<'a, T: 'a, S> ParallelExtend<&'a T> for IndexSet<T, S>
 where
     T: Copy + Eq + Hash + Send + Sync,

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -2,8 +2,8 @@
 //!
 //! You will rarely need to interact with this module directly unless you need to name one of the
 //! iterator types.
-//!
-//! Requires crate feature `"rayon"`.
+
+#![cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 
 use super::collect;
 use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
@@ -22,7 +22,7 @@ use crate::IndexSet;
 
 type Bucket<T> = crate::Bucket<T, ()>;
 
-/// Requires crate feature `"rayon"`.
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<T, S> IntoParallelIterator for IndexSet<T, S>
 where
     T: Send,
@@ -37,7 +37,7 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<T> IntoParallelIterator for Box<Slice<T>>
 where
     T: Send,
@@ -80,7 +80,7 @@ impl<T: Send> IndexedParallelIterator for IntoParIter<T> {
     indexed_parallel_iterator_methods!(Bucket::key);
 }
 
-/// Requires crate feature `"rayon"`.
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<'a, T, S> IntoParallelIterator for &'a IndexSet<T, S>
 where
     T: Sync,
@@ -95,7 +95,7 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<'a, T> IntoParallelIterator for &'a Slice<T>
 where
     T: Sync,
@@ -144,7 +144,7 @@ impl<T: Sync> IndexedParallelIterator for ParIter<'_, T> {
     indexed_parallel_iterator_methods!(Bucket::key_ref);
 }
 
-/// Requires crate feature `"rayon"`.
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<'a, T, S> ParallelDrainRange<usize> for &'a mut IndexSet<T, S>
 where
     T: Send,
@@ -585,7 +585,7 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<T, S> FromParallelIterator<T> for IndexSet<T, S>
 where
     T: Eq + Hash + Send,
@@ -605,7 +605,7 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<T, S> ParallelExtend<T> for IndexSet<T, S>
 where
     T: Eq + Hash + Send,
@@ -621,7 +621,7 @@ where
     }
 }
 
-/// Requires crate feature `"rayon"`.
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 impl<'a, T: 'a, S> ParallelExtend<&'a T> for IndexSet<T, S>
 where
     T: Copy + Eq + Hash + Send + Sync,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-
 use serde::de::value::{MapDeserializer, SeqDeserializer};
 use serde::de::{
     Deserialize, Deserializer, Error, IntoDeserializer, MapAccess, SeqAccess, Visitor,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+
 use serde::de::value::{MapDeserializer, SeqDeserializer};
 use serde::de::{
     Deserialize, Deserializer, Error, IntoDeserializer, MapAccess, SeqAccess, Visitor,
@@ -10,7 +12,6 @@ use core::marker::PhantomData;
 
 use crate::IndexMap;
 
-/// Requires crate feature `"serde"`
 impl<K, V, S> Serialize for IndexMap<K, V, S>
 where
     K: Serialize + Hash + Eq,
@@ -54,7 +55,6 @@ where
     }
 }
 
-/// Requires crate feature `"serde"`
 impl<'de, K, V, S> Deserialize<'de> for IndexMap<K, V, S>
 where
     K: Deserialize<'de> + Eq + Hash,
@@ -85,7 +85,6 @@ where
 
 use crate::IndexSet;
 
-/// Requires crate feature `"serde"`
 impl<T, S> Serialize for IndexSet<T, S>
 where
     T: Serialize + Hash + Eq,
@@ -127,7 +126,6 @@ where
     }
 }
 
-/// Requires crate feature `"serde"`
 impl<'de, T, S> Deserialize<'de> for IndexSet<T, S>
 where
     T: Deserialize<'de> + Eq + Hash,

--- a/src/serde_seq.rs
+++ b/src/serde_seq.rs
@@ -18,8 +18,6 @@
 //! }
 //! ```
 
-#![cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-
 use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
 use serde::ser::{Serialize, Serializer};
 

--- a/src/serde_seq.rs
+++ b/src/serde_seq.rs
@@ -17,8 +17,8 @@
 //!     // ...
 //! }
 //! ```
-//!
-//! Requires crate feature `"serde"`
+
+#![cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 
 use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
 use serde::ser::{Serialize, Serializer};
@@ -35,8 +35,6 @@ use crate::IndexMap;
 ///
 /// This behaves like [`crate::serde_seq`] for `IndexMap`, serializing a sequence
 /// of `(key, value)` pairs, rather than as a map that might not preserve order.
-///
-/// Requires crate feature `"serde"`
 impl<K, V> Serialize for MapSlice<K, V>
 where
     K: Serialize,
@@ -51,8 +49,6 @@ where
 }
 
 /// Serializes a `set::Slice` as an ordered sequence.
-///
-/// Requires crate feature `"serde"`
 impl<T> Serialize for SetSlice<T>
 where
     T: Serialize,
@@ -79,8 +75,6 @@ where
 ///     // ...
 /// }
 /// ```
-///
-/// Requires crate feature `"serde"`
 pub fn serialize<K, V, S, T>(map: &IndexMap<K, V, S>, serializer: T) -> Result<T::Ok, T::Error>
 where
     K: Serialize + Hash + Eq,
@@ -135,8 +129,6 @@ where
 ///     // ...
 /// }
 /// ```
-///
-/// Requires crate feature `"serde"`
 pub fn deserialize<'de, D, K, V, S>(deserializer: D) -> Result<IndexMap<K, V, S>, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/set.rs
+++ b/src/set.rs
@@ -135,6 +135,7 @@ where
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<T> IndexSet<T> {
     /// Create a new set. (Does not allocate.)
     pub fn new() -> Self {
@@ -841,6 +842,7 @@ where
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<T, const N: usize> From<[T; N]> for IndexSet<T, RandomState>
 where
     T: Eq + Hash,

--- a/test-serde/src/lib.rs
+++ b/test-serde/src/lib.rs
@@ -77,7 +77,7 @@ fn test_serde_seq_map() {
     #[derive(Debug, Deserialize, Serialize)]
     #[serde(transparent)]
     struct SeqIndexMap {
-        #[serde(with = "indexmap::serde_seq")]
+        #[serde(with = "indexmap::map::serde_seq")]
         map: IndexMap<i32, i32>,
     }
 


### PR DESCRIPTION
In this PR I've added a couple of commits to:

1. Use the [`doc_cfg`](https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html) feature to improve readability of certain items in the crate which are locked behind feature flags.
2. Update the crate-level documentation for what the feature flags actually do.

I'm hoping this will improve clarity on the `serde` feature; it wasn't immediately clear to me that the `serde` feature enabled `Serialize` and `Deserialize` implementations, and that the functions in `serde_seq` were actually an alternative implementation for `IndexMap` specifically.

I also think that we should consider moving the `serde_seq` module from the crate root into the `map` module (similar to how the `rayon` module is organised under the `map` and `set` modules). As this module is specific to `IndexMap` I think it would be better namespaced under the `map` module. This will also help users that Ctrl+f for "serde" on the docs.rs landing page find the feature-flag documentation immediately.