### PR TITLE
Implement Default for iterators

### DIFF
--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -89,6 +89,12 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Iter<'_, K, V> {
     }
 }
 
+impl<K, V> Default for Iter<'_, K, V> {
+    fn default() -> Self {
+        Self { iter: [].iter() }
+    }
+}
+
 /// A mutable iterator over the entries of a `IndexMap`.
 ///
 /// This `struct` is created by the [`iter_mut`] method on [`IndexMap`]. See its
@@ -145,6 +151,14 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for IterMut<'_, K, V> {
     }
 }
 
+impl<K, V> Default for IterMut<'_, K, V> {
+    fn default() -> Self {
+        Self {
+            iter: [].iter_mut(),
+        }
+    }
+}
+
 /// An owning iterator over the entries of a `IndexMap`.
 ///
 /// This `struct` is created by the [`into_iter`] method on [`IndexMap`]
@@ -196,6 +210,14 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for IntoIter<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let iter = self.iter.as_slice().iter().map(Bucket::refs);
         f.debug_list().entries(iter).finish()
+    }
+}
+
+impl<K, V> Default for IntoIter<K, V> {
+    fn default() -> Self {
+        Self {
+            iter: Vec::new().into_iter(),
+        }
     }
 }
 
@@ -298,6 +320,12 @@ impl<K: fmt::Debug, V> fmt::Debug for Keys<'_, K, V> {
     }
 }
 
+impl<K, V> Default for Keys<'_, K, V> {
+    fn default() -> Self {
+        Self { iter: [].iter() }
+    }
+}
+
 /// An owning iterator over the keys of a `IndexMap`.
 ///
 /// This `struct` is created by the [`into_keys`] method on [`IndexMap`].
@@ -339,6 +367,14 @@ impl<K: fmt::Debug, V> fmt::Debug for IntoKeys<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let iter = self.iter.as_slice().iter().map(Bucket::key_ref);
         f.debug_list().entries(iter).finish()
+    }
+}
+
+impl<K, V> Default for IntoKeys<K, V> {
+    fn default() -> Self {
+        Self {
+            iter: Vec::new().into_iter(),
+        }
     }
 }
 
@@ -394,6 +430,12 @@ impl<K, V: fmt::Debug> fmt::Debug for Values<'_, K, V> {
     }
 }
 
+impl<K, V> Default for Values<'_, K, V> {
+    fn default() -> Self {
+        Self { iter: [].iter() }
+    }
+}
+
 /// A mutable iterator over the values of a `IndexMap`.
 ///
 /// This `struct` is created by the [`values_mut`] method on [`IndexMap`]. See its
@@ -438,6 +480,14 @@ impl<K, V: fmt::Debug> fmt::Debug for ValuesMut<'_, K, V> {
     }
 }
 
+impl<K, V> Default for ValuesMut<'_, K, V> {
+    fn default() -> Self {
+        Self {
+            iter: [].iter_mut(),
+        }
+    }
+}
+
 /// An owning iterator over the values of a `IndexMap`.
 ///
 /// This `struct` is created by the [`into_values`] method on [`IndexMap`].
@@ -479,5 +529,13 @@ impl<K, V: fmt::Debug> fmt::Debug for IntoValues<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let iter = self.iter.as_slice().iter().map(Bucket::value_ref);
         f.debug_list().entries(iter).finish()
+    }
+}
+
+impl<K, V> Default for IntoValues<K, V> {
+    fn default() -> Self {
+        Self {
+            iter: Vec::new().into_iter(),
+        }
     }
 }

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -427,3 +427,23 @@ fn from_array() {
 
     assert_eq!(map, expected)
 }
+
+#[test]
+fn iter_default() {
+    struct K;
+    struct V;
+    fn assert_default<T>()
+    where
+        T: Default + Iterator,
+    {
+        assert!(T::default().next().is_none());
+    }
+    assert_default::<Iter<'static, K, V>>();
+    assert_default::<IterMut<'static, K, V>>();
+    assert_default::<IntoIter<K, V>>();
+    assert_default::<Keys<'static, K, V>>();
+    assert_default::<IntoKeys<K, V>>();
+    assert_default::<Values<'static, K, V>>();
+    assert_default::<ValuesMut<'static, K, V>>();
+    assert_default::<IntoValues<K, V>>();
+}

--- a/src/set/iter.rs
+++ b/src/set/iter.rs
@@ -80,6 +80,12 @@ impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
     }
 }
 
+impl<T> Default for Iter<'_, T> {
+    fn default() -> Self {
+        Self { iter: [].iter() }
+    }
+}
+
 /// An owning iterator over the items of a `IndexSet`.
 ///
 /// This `struct` is created by the [`into_iter`] method on [`IndexSet`]
@@ -126,6 +132,14 @@ impl<T: fmt::Debug> fmt::Debug for IntoIter<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let iter = self.iter.as_slice().iter().map(Bucket::key_ref);
         f.debug_list().entries(iter).finish()
+    }
+}
+
+impl<T> Default for IntoIter<T> {
+    fn default() -> Self {
+        Self {
+            iter: Vec::new().into_iter(),
+        }
     }
 }
 

--- a/src/set/tests.rs
+++ b/src/set/tests.rs
@@ -530,3 +530,16 @@ fn from_array() {
 
     assert_eq!(set1, set2);
 }
+
+#[test]
+fn iter_default() {
+    struct Item;
+    fn assert_default<T>()
+    where
+        T: Default + Iterator,
+    {
+        assert!(T::default().next().is_none());
+    }
+    assert_default::<Iter<'static, Item>>();
+    assert_default::<IntoIter<Item>>();
+}


### PR DESCRIPTION
This matches `Default` implementations for HashMap and HashSet introduced in Rust 1.70 (https://github.com/rust-lang/rust/pull/99929/).