### PR TITLE
Upgrade to hashbrown 0.14 (MSRV 1.64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.61.0 # MSRV
+          - rust: 1.64.0 # MSRV
             features:
           - rust: stable
             features: arbitrary
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.61.0
+          - rust: 1.64.0
             target: thumbv6m-none-eabi
           - rust: stable
             target: thumbv6m-none-eabi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR MIT"
 description = "A hash table with consistent order and fast iteration."
 keywords = ["hashmap", "no_std"]
 categories = ["data-structures", "no-std"]
-rust-version = "1.61"
+rust-version = "1.64"
 
 [lib]
 bench = false
@@ -25,7 +25,7 @@ rayon = { version = "1.5.3", optional = true }
 rustc-rayon = { package = "rustc-rayon", version = "0.5", optional = true }
 
 [dependencies.hashbrown]
-version = "0.13"
+version = "0.14"
 default-features = false
 features = ["raw"]
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build status](https://github.com/bluss/indexmap/workflows/Continuous%20integration/badge.svg?branch=master)](https://github.com/bluss/indexmap/actions)
 [![crates.io](https://img.shields.io/crates/v/indexmap.svg)](https://crates.io/crates/indexmap)
 [![docs](https://docs.rs/indexmap/badge.svg)](https://docs.rs/indexmap)
-[![rustc](https://img.shields.io/badge/rust-1.61%2B-orange.svg)](https://img.shields.io/badge/rust-1.61%2B-orange.svg)
+[![rustc](https://img.shields.io/badge/rust-1.64%2B-orange.svg)](https://img.shields.io/badge/rust-1.64%2B-orange.svg)
 
 A pure-Rust hash table which preserves (in a limited sense) insertion order.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -26,7 +26,7 @@
     However, exactness only applies to the direct capacity for items, while the
     raw hash table still follows its own rules for capacity and load factor.
 
-  - The `hashbrown` dependency has been updated to version 0.13.
+  - The `hashbrown` dependency has been updated to version 0.14.
 
   - The `serde_seq` module has been moved from the crate root to below the
     `map` module.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 - 2.0.0 (pending)
 
-  - **MSRV**: Rust 1.61.0 or later is now required.
+  - **MSRV**: Rust 1.64.0 or later is now required.
 
   - The `"std"` feature is no longer auto-detected. It is included in the
     default feature set, or else can be enabled like any other Cargo feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //!
 //! ### Rust Version
 //!
-//! This version of indexmap requires Rust 1.61 or later.
+//! This version of indexmap requires Rust 1.64 or later.
 //!
 //! The indexmap 2.x release series will use a carefully considered version
 //! upgrade policy, where in a later 2.x version, we will raise the minimum

--- a/src/map/core/raw.rs
+++ b/src/map/core/raw.rs
@@ -172,7 +172,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
         // SAFETY: This is safe because it can only happen once (self is consumed)
         // and map.indices have not been modified since entry construction
         let index = unsafe { self.map.indices.remove(self.raw_bucket) };
-        self.map.swap_remove_finish(index)
+        self.map.swap_remove_finish(index.0)
     }
 
     /// Remove and return the key, value pair stored in the map for this entry
@@ -186,6 +186,6 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
         // SAFETY: This is safe because it can only happen once (self is consumed)
         // and map.indices have not been modified since entry construction
         let index = unsafe { self.map.indices.remove(self.raw_bucket) };
-        self.map.shift_remove_finish(index)
+        self.map.shift_remove_finish(index.0)
     }
 }

--- a/src/map/core/raw.rs
+++ b/src/map/core/raw.rs
@@ -171,8 +171,8 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     pub fn swap_remove_entry(self) -> (K, V) {
         // SAFETY: This is safe because it can only happen once (self is consumed)
         // and map.indices have not been modified since entry construction
-        let index = unsafe { self.map.indices.remove(self.raw_bucket) };
-        self.map.swap_remove_finish(index.0)
+        let (index, _slot) = unsafe { self.map.indices.remove(self.raw_bucket) };
+        self.map.swap_remove_finish(index)
     }
 
     /// Remove and return the key, value pair stored in the map for this entry
@@ -185,7 +185,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     pub fn shift_remove_entry(self) -> (K, V) {
         // SAFETY: This is safe because it can only happen once (self is consumed)
         // and map.indices have not been modified since entry construction
-        let index = unsafe { self.map.indices.remove(self.raw_bucket) };
-        self.map.shift_remove_finish(index.0)
+        let (index, _slot) = unsafe { self.map.indices.remove(self.raw_bucket) };
+        self.map.shift_remove_finish(index)
     }
 }


### PR DESCRIPTION
See https://github.com/rust-lang/hashbrown/blob/v0.14.0/CHANGELOG.md.
Bumps the MSRV to 1.64.

Related #243.