### PR TITLE
Use hashbrown's new single-lookup insertion

### DIFF
--- a/src/set.rs
+++ b/src/set.rs
@@ -335,16 +335,8 @@ where
     ///
     /// Computes in **O(1)** time (amortized average).
     pub fn insert_full(&mut self, value: T) -> (usize, bool) {
-        use super::map::Entry::*;
-
-        match self.map.entry(value) {
-            Occupied(e) => (e.index(), false),
-            Vacant(e) => {
-                let index = e.index();
-                e.insert(());
-                (index, true)
-            }
-        }
+        let (index, existing) = self.map.insert_full(value, ());
+        (index, existing.is_none())
     }
 
     /// Return an iterator over the values that are in `self` but not `other`.


### PR DESCRIPTION
With `find_or_find_insert_slot` and `insert_in_slot`, we can avoid an
extra insertion lookup after checking for existence. However, that also
reserves space for a new entry *before* checking existence, so it's a
little biased towards new items. For that reason, we're not using this
for map `entry` or set `replace`, as both imply a little more weight on
the expectation that it may already exist.
