### PR TITLE
Test `direct-minimal-versions`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,21 @@ jobs:
         with:
           components: miri
       - run: cargo miri test
+
+  minimal-versions:
+    name: Check MSRV and minimal-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.64.0 # MSRV
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+      - run: cargo +nightly hack generate-lockfile --remove-dev-deps -Z direct-minimal-versions
+      - name: Build
+        run: cargo build --verbose --all-features


### PR DESCRIPTION
This builds the crate with [`direct-minimal-versions`](https://doc.rust-lang.org/cargo/reference/unstable.html#direct-minimal-versions) checking if the crate actually builds with the minimal dependency versions specified.

Using [`taiki-e/install-action`](https://github.com/marketplace/actions/install-development-tools) to install [`cargo-hack`](https://crates.io/crates/cargo-hack) specifically to use `--remove-dev-deps` to get the actual minimal versions users can use. If these CI dependencies are undesirable, I can make an out-of-workspace sub-crate that can have it's own lockfile without any dev-dependencies.

Cc #271.