### PR TITLE
Release 2.0.1 with `rust-version = "1.63"`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,11 @@ jobs:
       - run: cargo +nightly hack generate-lockfile --remove-dev-deps -Z direct-minimal-versions
       - name: Build
         run: cargo build --verbose --all-features
+
+  # See hashbrown#457: it can actually work with 1.63.0
+  relaxed-msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.63.0
+      - run: cargo test --verbose --ignore-rust-version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "indexmap"
 edition = "2021"
-version = "2.0.0"
+version = "2.0.1"
 documentation = "https://docs.rs/indexmap/"
 repository = "https://github.com/bluss/indexmap"
 license = "Apache-2.0 OR MIT"
 description = "A hash table with consistent order and fast iteration."
 keywords = ["hashmap", "no_std"]
 categories = ["data-structures", "no-std"]
-rust-version = "1.64"
+rust-version = "1.63"
 
 [lib]
 bench = false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build status](https://github.com/bluss/indexmap/workflows/Continuous%20integration/badge.svg?branch=master)](https://github.com/bluss/indexmap/actions)
 [![crates.io](https://img.shields.io/crates/v/indexmap.svg)](https://crates.io/crates/indexmap)
 [![docs](https://docs.rs/indexmap/badge.svg)](https://docs.rs/indexmap)
-[![rustc](https://img.shields.io/badge/rust-1.64%2B-orange.svg)](https://img.shields.io/badge/rust-1.64%2B-orange.svg)
+[![rustc](https://img.shields.io/badge/rust-1.63%2B-orange.svg)](https://img.shields.io/badge/rust-1.63%2B-orange.svg)
 
 A pure-Rust hash table which preserves (in a limited sense) insertion order.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,8 @@
+- 2.0.1
+
+  - **MSRV**: Rust 1.63.0 is now supported as well, pending publication of
+    `hashbrown`'s relaxed MSRV (or use cargo `--ignore-rust-version`).
+
 - 2.0.0
 
   - **MSRV**: Rust 1.64.0 or later is now required.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //!
 //! ### Rust Version
 //!
-//! This version of indexmap requires Rust 1.64 or later.
+//! This version of indexmap requires Rust 1.63 or later.
 //!
 //! The indexmap 2.x release series will use a carefully considered version
 //! upgrade policy, where in a later 2.x version, we will raise the minimum


### PR DESCRIPTION
It won't fully work until rust-lang/hashbrown#457 is published, but we can at least signal our intent and test with `--ignore-rust-version` in CI.