### PR TITLE
Add `Slice::new` and `new_mut` for empty slices

### DIFF
--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -27,7 +27,7 @@ pub struct Slice<K, V> {
 // and reference lifetimes are bound together in function signatures.
 #[allow(unsafe_code)]
 impl<K, V> Slice<K, V> {
-    pub(super) fn from_slice(entries: &[Bucket<K, V>]) -> &Self {
+    pub(super) const fn from_slice(entries: &[Bucket<K, V>]) -> &Self {
         unsafe { &*(entries as *const [Bucket<K, V>] as *const Self) }
     }
 
@@ -49,15 +49,25 @@ impl<K, V> Slice<K, V> {
         self.into_boxed().into_vec()
     }
 
+    /// Returns an empty slice.
+    pub const fn new<'a>() -> &'a Self {
+        Self::from_slice(&[])
+    }
+
+    /// Returns an empty mutable slice.
+    pub fn new_mut<'a>() -> &'a mut Self {
+        Self::from_mut_slice(&mut [])
+    }
+
     /// Return the number of key-value pairs in the map slice.
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.entries.len()
     }
 
     /// Returns true if the map slice contains no elements.
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -24,7 +24,7 @@ pub struct Slice<T> {
 // and reference lifetimes are bound together in function signatures.
 #[allow(unsafe_code)]
 impl<T> Slice<T> {
-    pub(super) fn from_slice(entries: &[Bucket<T>]) -> &Self {
+    pub(super) const fn from_slice(entries: &[Bucket<T>]) -> &Self {
         unsafe { &*(entries as *const [Bucket<T>] as *const Self) }
     }
 
@@ -42,13 +42,18 @@ impl<T> Slice<T> {
         self.into_boxed().into_vec()
     }
 
+    /// Returns an empty slice.
+    pub const fn new<'a>() -> &'a Self {
+        Self::from_slice(&[])
+    }
+
     /// Return the number of elements in the set slice.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.entries.len()
     }
 
     /// Returns true if the set slice contains no elements.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 


### PR DESCRIPTION
* `pub const fn map::Slice::new<'a>() -> &'a Self`
* `pub fn map::Slice::new_mut<'a>() -> &'a mut Self`
* `pub const fn set::Slice::new<'a>() -> &'a Self`

In addition, the existing `len` and `is_empty` are now `const fn`.
