### PR TITLE
add binary_search and friends

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -796,12 +796,11 @@ where
 
     /// Search over a sorted map for a key.
     ///
-    /// Returns the position where that key is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search`] for more details.
+    /// Returns the position where that key is present, or the position where it can be inserted to
+    /// maintain the sort. See [`slice::binary_search`] for more details.
     ///
-    /// Computes in **O(log(n))** time,
-    /// which is notably less scalable than looking the key up using [`get_index_of`],
-    /// but this can also position missing keys.
+    /// Computes in **O(log(n))** time, which is notably less scalable than looking the key up
+    /// using [`get_index_of`][IndexMap::get_index_of], but this can also position missing keys.
     pub fn binary_search_keys(&self, x: &K) -> Result<usize, usize>
     where
         K: Ord,
@@ -811,8 +810,8 @@ where
 
     /// Search over a sorted map with a comparator function.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search_by`] for more details.
+    /// Returns the position where that value is present, or the position where it can be inserted
+    /// to maintain the sort. See [`slice::binary_search_by`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -825,8 +824,8 @@ where
 
     /// Search over a sorted map with an extraction function.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search_by_key`] for more details.
+    /// Returns the position where that value is present, or the position where it can be inserted
+    /// to maintain the sort. See [`slice::binary_search_by_key`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]

--- a/src/map.rs
+++ b/src/map.rs
@@ -797,7 +797,7 @@ where
     /// Search over a sorted map with a comparator function.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// see [`slice::binary_search_by`] for more details.
+    /// See [`slice::binary_search_by`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -811,7 +811,7 @@ where
     /// Search over a sorted map with an extraction function.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// see [`slice::binary_search_by_key`] for more details.
+    /// See [`slice::binary_search_by_key`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -826,7 +826,7 @@ where
     /// Returns the index of the partition point of a sorted map according to the given predicate
     /// (the index of the first element of the second partition).
     ///
-    /// see [`slice::partition_point`] for more details.
+    /// See [`slice::partition_point`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[must_use]

--- a/src/map.rs
+++ b/src/map.rs
@@ -794,6 +794,46 @@ where
         });
     }
 
+    /// Search over a sorted map with a comparator function.
+    ///
+    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
+    /// see [slice::binary_search_by] for more details.
+    /// **O(log(n))**
+    #[inline]
+    pub fn binary_search_by<'a, F>(&'a self, f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&'a K, &'a V) -> Ordering,
+    {
+        self.as_slice().binary_search_by(f)
+    }
+
+    /// Search over a sorted map with a key extraction function.
+    ///
+    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
+    /// see [slice::binary_search_by_key] for more details.
+    /// **O(log(n))**
+    #[inline]
+    pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&'a K, &'a V) -> B,
+        B: Ord,
+    {
+        self.as_slice().binary_search_by_key(b, f)
+    }
+
+    /// Returns the index of the partition point or a sorted map according to the given predicate
+    /// (the index of the first element of the second partition).
+    ///
+    /// see [slice::partition_point] for more details.
+    /// **O(log(n))**
+    #[must_use]
+    pub fn partition_point<P>(&self, pred: P) -> usize
+    where
+        P: FnMut(&K, &V) -> bool,
+    {
+        self.as_slice().partition_point(pred)
+    }
+
     /// Reverses the order of the map’s key-value pairs in place.
     ///
     /// Computes in **O(n)** time and **O(1)** space.

--- a/src/map.rs
+++ b/src/map.rs
@@ -794,6 +794,21 @@ where
         });
     }
 
+    /// Search over a sorted map for a key.
+    ///
+    /// Returns the position where that key is present, or the position where it can be inserted to maintain the sort.
+    /// See [`slice::binary_search`] for more details.
+    ///
+    /// Computes in **O(log(n))** time,
+    /// which is notably less scalable than looking the key up using [`get_index_of`],
+    /// but this can also position missing keys.
+    pub fn binary_search_keys(&self, x: &K) -> Result<usize, usize>
+    where
+        K: Ord,
+    {
+        self.as_slice().binary_search_keys(x)
+    }
+
     /// Search over a sorted map with a comparator function.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.

--- a/src/map.rs
+++ b/src/map.rs
@@ -796,9 +796,10 @@ where
 
     /// Search over a sorted map with a comparator function.
     ///
-    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
-    /// see [slice::binary_search_by] for more details.
-    /// **O(log(n))**
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// see [`slice::binary_search_by`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[inline]
     pub fn binary_search_by<'a, F>(&'a self, f: F) -> Result<usize, usize>
     where
@@ -807,11 +808,12 @@ where
         self.as_slice().binary_search_by(f)
     }
 
-    /// Search over a sorted map with a key extraction function.
+    /// Search over a sorted map with an extraction function.
     ///
-    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
-    /// see [slice::binary_search_by_key] for more details.
-    /// **O(log(n))**
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// see [`slice::binary_search_by_key`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[inline]
     pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, f: F) -> Result<usize, usize>
     where
@@ -821,11 +823,12 @@ where
         self.as_slice().binary_search_by_key(b, f)
     }
 
-    /// Returns the index of the partition point or a sorted map according to the given predicate
+    /// Returns the index of the partition point of a sorted map according to the given predicate
     /// (the index of the first element of the second partition).
     ///
-    /// see [slice::partition_point] for more details.
-    /// **O(log(n))**
+    /// see [`slice::partition_point`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[must_use]
     pub fn partition_point<P>(&self, pred: P) -> usize
     where

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -204,12 +204,12 @@ impl<K, V> Slice<K, V> {
 
     /// Search over a sorted map for a key.
     ///
-    /// Returns the position where that key is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search`] for more details.
+    /// Returns the position where that key is present, or the position where it can be inserted to
+    /// maintain the sort. See [`slice::binary_search`] for more details.
     ///
-    /// Computes in **O(log(n))** time,
-    /// which is notably less scalable than looking the key up in the map this is a slice from
-    /// using [`IndexMap::get_index_of`], but this can also position missing keys.
+    /// Computes in **O(log(n))** time, which is notably less scalable than looking the key up in
+    /// the map this is a slice from using [`IndexMap::get_index_of`], but this can also position
+    /// missing keys.
     pub fn binary_search_keys(&self, x: &K) -> Result<usize, usize>
     where
         K: Ord,
@@ -219,8 +219,8 @@ impl<K, V> Slice<K, V> {
 
     /// Search over a sorted map with a comparator function.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search_by`] for more details.
+    /// Returns the position where that value is present, or the position where it can be inserted
+    /// to maintain the sort. See [`slice::binary_search_by`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -233,8 +233,8 @@ impl<K, V> Slice<K, V> {
 
     /// Search over a sorted map with an extraction function.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search_by_key`] for more details.
+    /// Returns the position where that value is present, or the position where it can be inserted
+    /// to maintain the sort. See [`slice::binary_search_by_key`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -201,6 +201,59 @@ impl<K, V> Slice<K, V> {
     pub fn into_values(self: Box<Self>) -> IntoValues<K, V> {
         IntoValues::new(self.into_entries())
     }
+
+    /// Search over a sorted map for a value.
+    ///
+    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
+    /// see [slice::binary_search] for more details.
+    /// **O(log(n))**, which is notably less scalable than looking the value up in the map set is a slice from.
+    pub fn binary_search_keys(&self, x: &K) -> Result<usize, usize>
+    where
+        K: Ord,
+    {
+        self.binary_search_by(|p, _| p.cmp(x))
+    }
+
+    /// Search over a sorted map with a comparator function.
+    ///
+    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
+    /// see [slice::binary_search_by] for more details.
+    /// **O(log(n))**
+    #[inline]
+    pub fn binary_search_by<'a, F>(&'a self, mut f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&'a K, &'a V) -> Ordering,
+    {
+        self.entries.binary_search_by(move |a| f(&a.key, &a.value))
+    }
+
+    /// Search over a sorted map with a key extraction function.
+    ///
+    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
+    /// see [slice::binary_search_by_key] for more details.
+    /// **O(log(n))**
+    #[inline]
+    pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, mut f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&'a K, &'a V) -> B,
+        B: Ord,
+    {
+        self.binary_search_by(|k, v| f(k, v).cmp(b))
+    }
+
+    /// Returns the index of the partition point or a sorted map according to the given predicate
+    /// (the index of the first element of the second partition).
+    ///
+    /// see [slice::partition_point] for more details.
+    /// **O(log(n))**
+    #[must_use]
+    pub fn partition_point<P>(&self, mut pred: P) -> usize
+    where
+        P: FnMut(&K, &V) -> bool,
+    {
+        self.entries
+            .partition_point(move |a| pred(&a.key, &a.value))
+    }
 }
 
 impl<'a, K, V> IntoIterator for &'a Slice<K, V> {

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -205,7 +205,7 @@ impl<K, V> Slice<K, V> {
     /// Search over a sorted map for a key.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// see [`slice::binary_search`] for more details.
+    /// See [`slice::binary_search`] for more details.
     ///
     /// Computes in **O(log(n))** time,
     /// which is notably less scalable than looking the value up in the map this is a slice from.
@@ -219,7 +219,7 @@ impl<K, V> Slice<K, V> {
     /// Search over a sorted map with a comparator function.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// see [`slice::binary_search_by`] for more details.
+    /// See [`slice::binary_search_by`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -233,7 +233,7 @@ impl<K, V> Slice<K, V> {
     /// Search over a sorted map with an extraction function.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// see [`slice::binary_search_by_key`] for more details.
+    /// See [`slice::binary_search_by_key`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -248,7 +248,7 @@ impl<K, V> Slice<K, V> {
     /// Returns the index of the partition point of a sorted map according to the given predicate
     /// (the index of the first element of the second partition).
     ///
-    /// see [`slice::partition_point`] for more details.
+    /// See [`slice::partition_point`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[must_use]

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -202,11 +202,13 @@ impl<K, V> Slice<K, V> {
         IntoValues::new(self.into_entries())
     }
 
-    /// Search over a sorted map for a value.
+    /// Search over a sorted map for a key.
     ///
-    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
-    /// see [slice::binary_search] for more details.
-    /// **O(log(n))**, which is notably less scalable than looking the value up in the map set is a slice from.
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// see [`slice::binary_search`] for more details.
+    ///
+    /// Computes in **O(log(n))** time,
+    /// which is notably less scalable than looking the value up in the map this is a slice from.
     pub fn binary_search_keys(&self, x: &K) -> Result<usize, usize>
     where
         K: Ord,
@@ -216,9 +218,10 @@ impl<K, V> Slice<K, V> {
 
     /// Search over a sorted map with a comparator function.
     ///
-    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
-    /// see [slice::binary_search_by] for more details.
-    /// **O(log(n))**
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// see [`slice::binary_search_by`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[inline]
     pub fn binary_search_by<'a, F>(&'a self, mut f: F) -> Result<usize, usize>
     where
@@ -227,11 +230,12 @@ impl<K, V> Slice<K, V> {
         self.entries.binary_search_by(move |a| f(&a.key, &a.value))
     }
 
-    /// Search over a sorted map with a key extraction function.
+    /// Search over a sorted map with an extraction function.
     ///
-    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
-    /// see [slice::binary_search_by_key] for more details.
-    /// **O(log(n))**
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// see [`slice::binary_search_by_key`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[inline]
     pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, mut f: F) -> Result<usize, usize>
     where
@@ -241,11 +245,12 @@ impl<K, V> Slice<K, V> {
         self.binary_search_by(|k, v| f(k, v).cmp(b))
     }
 
-    /// Returns the index of the partition point or a sorted map according to the given predicate
+    /// Returns the index of the partition point of a sorted map according to the given predicate
     /// (the index of the first element of the second partition).
     ///
-    /// see [slice::partition_point] for more details.
-    /// **O(log(n))**
+    /// see [`slice::partition_point`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[must_use]
     pub fn partition_point<P>(&self, mut pred: P) -> usize
     where

--- a/src/map/slice.rs
+++ b/src/map/slice.rs
@@ -204,11 +204,12 @@ impl<K, V> Slice<K, V> {
 
     /// Search over a sorted map for a key.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// Returns the position where that key is present, or the position where it can be inserted to maintain the sort.
     /// See [`slice::binary_search`] for more details.
     ///
     /// Computes in **O(log(n))** time,
-    /// which is notably less scalable than looking the value up in the map this is a slice from.
+    /// which is notably less scalable than looking the key up in the map this is a slice from
+    /// using [`IndexMap::get_index_of`], but this can also position missing keys.
     pub fn binary_search_keys(&self, x: &K) -> Result<usize, usize>
     where
         K: Ord,

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -447,3 +447,224 @@ fn iter_default() {
     assert_default::<ValuesMut<'static, K, V>>();
     assert_default::<IntoValues<K, V>>();
 }
+
+#[test]
+fn test_binary_search_by() {
+    // addaped from stds test for binary_search
+    let b: IndexMap<_, i32> = []
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&5)), Err(0));
+
+    let b: IndexMap<_, i32> = [4]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&3)), Err(0));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&4)), Ok(0));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&5)), Err(1));
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 6, 8, 9]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&5)), Err(3));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&6)), Ok(3));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&7)), Err(4));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&8)), Ok(4));
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 5, 6, 8]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&9)), Err(6));
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 6, 7, 8, 9]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&6)), Ok(3));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&5)), Err(3));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&8)), Ok(5));
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 5, 6, 8, 9]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&7)), Err(5));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&0)), Err(0));
+
+    let b: IndexMap<_, i32> = [1, 3, 3, 3, 7]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&0)), Err(0));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&1)), Ok(0));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&2)), Err(1));
+    assert!(match b.binary_search_by(|_, x| x.cmp(&3)) {
+        Ok(1..=3) => true,
+        _ => false,
+    });
+    assert!(match b.binary_search_by(|_, x| x.cmp(&3)) {
+        Ok(1..=3) => true,
+        _ => false,
+    });
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&4)), Err(4));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&5)), Err(4));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&6)), Err(4));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&7)), Ok(4));
+    assert_eq!(b.binary_search_by(|_, x| x.cmp(&8)), Err(5));
+}
+
+#[test]
+fn test_binary_search_by_key() {
+    // addaped from stds test for binary_search
+    let b: IndexMap<_, i32> = []
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by_key(&5, |_, &x| x), Err(0));
+
+    let b: IndexMap<_, i32> = [4]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by_key(&3, |_, &x| x), Err(0));
+    assert_eq!(b.binary_search_by_key(&4, |_, &x| x), Ok(0));
+    assert_eq!(b.binary_search_by_key(&5, |_, &x| x), Err(1));
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 6, 8, 9]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by_key(&5, |_, &x| x), Err(3));
+    assert_eq!(b.binary_search_by_key(&6, |_, &x| x), Ok(3));
+    assert_eq!(b.binary_search_by_key(&7, |_, &x| x), Err(4));
+    assert_eq!(b.binary_search_by_key(&8, |_, &x| x), Ok(4));
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 5, 6, 8]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by_key(&9, |_, &x| x), Err(6));
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 6, 7, 8, 9]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by_key(&6, |_, &x| x), Ok(3));
+    assert_eq!(b.binary_search_by_key(&5, |_, &x| x), Err(3));
+    assert_eq!(b.binary_search_by_key(&8, |_, &x| x), Ok(5));
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 5, 6, 8, 9]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by_key(&7, |_, &x| x), Err(5));
+    assert_eq!(b.binary_search_by_key(&0, |_, &x| x), Err(0));
+
+    let b: IndexMap<_, i32> = [1, 3, 3, 3, 7]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.binary_search_by_key(&0, |_, &x| x), Err(0));
+    assert_eq!(b.binary_search_by_key(&1, |_, &x| x), Ok(0));
+    assert_eq!(b.binary_search_by_key(&2, |_, &x| x), Err(1));
+    assert!(match b.binary_search_by_key(&3, |_, &x| x) {
+        Ok(1..=3) => true,
+        _ => false,
+    });
+    assert!(match b.binary_search_by_key(&3, |_, &x| x) {
+        Ok(1..=3) => true,
+        _ => false,
+    });
+    assert_eq!(b.binary_search_by_key(&4, |_, &x| x), Err(4));
+    assert_eq!(b.binary_search_by_key(&5, |_, &x| x), Err(4));
+    assert_eq!(b.binary_search_by_key(&6, |_, &x| x), Err(4));
+    assert_eq!(b.binary_search_by_key(&7, |_, &x| x), Ok(4));
+    assert_eq!(b.binary_search_by_key(&8, |_, &x| x), Err(5));
+}
+
+#[test]
+fn test_partition_point() {
+    // addaped from stds test for partition_point
+    let b: IndexMap<_, i32> = []
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.partition_point(|_, &x| x < 5), 0);
+
+    let b: IndexMap<_, i32> = [4]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.partition_point(|_, &x| x < 3), 0);
+    assert_eq!(b.partition_point(|_, &x| x < 4), 0);
+    assert_eq!(b.partition_point(|_, &x| x < 5), 1);
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 6, 8, 9]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.partition_point(|_, &x| x < 5), 3);
+    assert_eq!(b.partition_point(|_, &x| x < 6), 3);
+    assert_eq!(b.partition_point(|_, &x| x < 7), 4);
+    assert_eq!(b.partition_point(|_, &x| x < 8), 4);
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 5, 6, 8]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.partition_point(|_, &x| x < 9), 6);
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 6, 7, 8, 9]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.partition_point(|_, &x| x < 6), 3);
+    assert_eq!(b.partition_point(|_, &x| x < 5), 3);
+    assert_eq!(b.partition_point(|_, &x| x < 8), 5);
+
+    let b: IndexMap<_, i32> = [1, 2, 4, 5, 6, 8, 9]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.partition_point(|_, &x| x < 7), 5);
+    assert_eq!(b.partition_point(|_, &x| x < 0), 0);
+
+    let b: IndexMap<_, i32> = [1, 3, 3, 3, 7]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+    assert_eq!(b.partition_point(|_, &x| x < 0), 0);
+    assert_eq!(b.partition_point(|_, &x| x < 1), 0);
+    assert_eq!(b.partition_point(|_, &x| x < 2), 1);
+    assert_eq!(b.partition_point(|_, &x| x < 3), 1);
+    assert_eq!(b.partition_point(|_, &x| x < 4), 4);
+    assert_eq!(b.partition_point(|_, &x| x < 5), 4);
+    assert_eq!(b.partition_point(|_, &x| x < 6), 4);
+    assert_eq!(b.partition_point(|_, &x| x < 7), 4);
+    assert_eq!(b.partition_point(|_, &x| x < 8), 5);
+}

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -450,7 +450,7 @@ fn iter_default() {
 
 #[test]
 fn test_binary_search_by() {
-    // addaped from stds test for binary_search
+    // adapted from std's test for binary_search
     let b: IndexMap<_, i32> = []
         .into_iter()
         .enumerate()
@@ -526,7 +526,7 @@ fn test_binary_search_by() {
 
 #[test]
 fn test_binary_search_by_key() {
-    // addaped from stds test for binary_search
+    // adapted from std's test for binary_search
     let b: IndexMap<_, i32> = []
         .into_iter()
         .enumerate()
@@ -602,7 +602,7 @@ fn test_binary_search_by_key() {
 
 #[test]
 fn test_partition_point() {
-    // addaped from stds test for partition_point
+    // adapted from std's test for partition_point
     let b: IndexMap<_, i32> = []
         .into_iter()
         .enumerate()

--- a/src/set.rs
+++ b/src/set.rs
@@ -688,6 +688,46 @@ where
         });
     }
 
+    /// Search over a sorted set with a comparator function.
+    ///
+    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
+    /// see [slice::binary_search_by] for more details.
+    /// **O(log(n))**
+    #[inline]
+    pub fn binary_search_by<'a, F>(&'a self, f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&'a T) -> Ordering,
+    {
+        self.as_slice().binary_search_by(f)
+    }
+
+    /// Search over a sorted set with a key extraction function.
+    ///
+    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
+    /// see [slice::binary_search_by_key] for more details.
+    /// **O(log(n))**
+    #[inline]
+    pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&'a T) -> B,
+        B: Ord,
+    {
+        self.as_slice().binary_search_by_key(b, f)
+    }
+
+    /// Returns the index of the partition point or a sorted set according to the given predicate
+    /// (the index of the first element of the second partition).
+    ///
+    /// see [slice::partition_point] for more details.
+    /// **O(log(n))**
+    #[must_use]
+    pub fn partition_point<P>(&self, pred: P) -> usize
+    where
+        P: FnMut(&T) -> bool,
+    {
+        self.as_slice().partition_point(pred)
+    }
+
     /// Reverses the order of the set’s values in place.
     ///
     /// Computes in **O(n)** time and **O(1)** space.

--- a/src/set.rs
+++ b/src/set.rs
@@ -691,7 +691,7 @@ where
     /// Search over a sorted set with a comparator function.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// see [`slice::binary_search_by`] for more details.
+    /// See [`slice::binary_search_by`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -705,7 +705,7 @@ where
     /// Search over a sorted set with an extraction function.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// see [`slice::binary_search_by_key`] for more details.
+    /// See [`slice::binary_search_by_key`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -720,7 +720,7 @@ where
     /// Returns the index of the partition point of a sorted set according to the given predicate
     /// (the index of the first element of the second partition).
     ///
-    /// see [`slice::partition_point`] for more details.
+    /// See [`slice::partition_point`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[must_use]

--- a/src/set.rs
+++ b/src/set.rs
@@ -690,9 +690,10 @@ where
 
     /// Search over a sorted set with a comparator function.
     ///
-    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
-    /// see [slice::binary_search_by] for more details.
-    /// **O(log(n))**
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// see [`slice::binary_search_by`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[inline]
     pub fn binary_search_by<'a, F>(&'a self, f: F) -> Result<usize, usize>
     where
@@ -701,11 +702,12 @@ where
         self.as_slice().binary_search_by(f)
     }
 
-    /// Search over a sorted set with a key extraction function.
+    /// Search over a sorted set with an extraction function.
     ///
-    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
-    /// see [slice::binary_search_by_key] for more details.
-    /// **O(log(n))**
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// see [`slice::binary_search_by_key`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[inline]
     pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, f: F) -> Result<usize, usize>
     where
@@ -715,11 +717,12 @@ where
         self.as_slice().binary_search_by_key(b, f)
     }
 
-    /// Returns the index of the partition point or a sorted set according to the given predicate
+    /// Returns the index of the partition point of a sorted set according to the given predicate
     /// (the index of the first element of the second partition).
     ///
-    /// see [slice::partition_point] for more details.
-    /// **O(log(n))**
+    /// see [`slice::partition_point`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[must_use]
     pub fn partition_point<P>(&self, pred: P) -> usize
     where

--- a/src/set.rs
+++ b/src/set.rs
@@ -690,12 +690,11 @@ where
 
     /// Search over a sorted set for a value.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search`] for more details.
+    /// Returns the position where that value is present, or the position where it can be inserted
+    /// to maintain the sort. See [`slice::binary_search`] for more details.
     ///
-    /// Computes in **O(log(n))** time,
-    /// which is notably less scalable than looking the value up using [`get_index_of`],
-    /// but this can also position missing values.
+    /// Computes in **O(log(n))** time, which is notably less scalable than looking the value up
+    /// using [`get_index_of`][IndexSet::get_index_of], but this can also position missing values.
     pub fn binary_search(&self, x: &T) -> Result<usize, usize>
     where
         T: Ord,
@@ -705,8 +704,8 @@ where
 
     /// Search over a sorted set with a comparator function.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search_by`] for more details.
+    /// Returns the position where that value is present, or the position where it can be inserted
+    /// to maintain the sort. See [`slice::binary_search_by`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -719,8 +718,8 @@ where
 
     /// Search over a sorted set with an extraction function.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search_by_key`] for more details.
+    /// Returns the position where that value is present, or the position where it can be inserted
+    /// to maintain the sort. See [`slice::binary_search_by_key`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]

--- a/src/set.rs
+++ b/src/set.rs
@@ -688,6 +688,21 @@ where
         });
     }
 
+    /// Search over a sorted set for a value.
+    ///
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// See [`slice::binary_search`] for more details.
+    ///
+    /// Computes in **O(log(n))** time,
+    /// which is notably less scalable than looking the value up using [`get_index_of`],
+    /// but this can also position missing values.
+    pub fn binary_search(&self, x: &T) -> Result<usize, usize>
+    where
+        T: Ord,
+    {
+        self.as_slice().binary_search(x)
+    }
+
     /// Search over a sorted set with a comparator function.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -109,6 +109,58 @@ impl<T> Slice<T> {
     pub fn iter(&self) -> Iter<'_, T> {
         Iter::new(&self.entries)
     }
+
+    /// Search over a sorted set for a value.
+    ///
+    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
+    /// see [slice::binary_search] for more details.
+    /// **O(log(n))**, which is notably less scalable than looking the value up in the set this is a slice from.
+    pub fn binary_search(&self, x: &T) -> Result<usize, usize>
+    where
+        T: Ord,
+    {
+        self.binary_search_by(|p| p.cmp(x))
+    }
+
+    /// Search over a sorted set with a comparator function.
+    ///
+    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
+    /// see [slice::binary_search_by] for more details.
+    /// **O(log(n))**
+    #[inline]
+    pub fn binary_search_by<'a, F>(&'a self, mut f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&'a T) -> Ordering,
+    {
+        self.entries.binary_search_by(move |a| f(&a.key))
+    }
+
+    /// Search over a sorted set with a key extraction function.
+    ///
+    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
+    /// see [slice::binary_search_by_key] for more details.
+    /// **O(log(n))**
+    #[inline]
+    pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, mut f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&'a T) -> B,
+        B: Ord,
+    {
+        self.binary_search_by(|k| f(k).cmp(b))
+    }
+
+    /// Returns the index of the partition point or a sorted set according to the given predicate
+    /// (the index of the first element of the second partition).
+    ///
+    /// see [slice::partition_point] for more details.
+    /// **O(log(n))**
+    #[must_use]
+    pub fn partition_point<P>(&self, mut pred: P) -> usize
+    where
+        P: FnMut(&T) -> bool,
+    {
+        self.entries.partition_point(move |a| pred(&a.key))
+    }
 }
 
 impl<'a, T> IntoIterator for &'a Slice<T> {

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -116,7 +116,8 @@ impl<T> Slice<T> {
     /// See [`slice::binary_search`] for more details.
     ///
     /// Computes in **O(log(n))** time,
-    /// which is notably less scalable than looking the value up in the set this is a slice from.
+    /// which is notably less scalable than looking the value up in the set this is a slice from
+    /// using [`IndexSet::get_index_of`], but this can also position missing values.
     pub fn binary_search(&self, x: &T) -> Result<usize, usize>
     where
         T: Ord,

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -112,12 +112,12 @@ impl<T> Slice<T> {
 
     /// Search over a sorted set for a value.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search`] for more details.
+    /// Returns the position where that value is present, or the position where it can be inserted
+    /// to maintain the sort. See [`slice::binary_search`] for more details.
     ///
-    /// Computes in **O(log(n))** time,
-    /// which is notably less scalable than looking the value up in the set this is a slice from
-    /// using [`IndexSet::get_index_of`], but this can also position missing values.
+    /// Computes in **O(log(n))** time, which is notably less scalable than looking the value up in
+    /// the set this is a slice from using [`IndexSet::get_index_of`], but this can also position
+    /// missing values.
     pub fn binary_search(&self, x: &T) -> Result<usize, usize>
     where
         T: Ord,
@@ -127,8 +127,8 @@ impl<T> Slice<T> {
 
     /// Search over a sorted set with a comparator function.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search_by`] for more details.
+    /// Returns the position where that value is present, or the position where it can be inserted
+    /// to maintain the sort. See [`slice::binary_search_by`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -141,8 +141,8 @@ impl<T> Slice<T> {
 
     /// Search over a sorted set with an extraction function.
     ///
-    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// See [`slice::binary_search_by_key`] for more details.
+    /// Returns the position where that value is present, or the position where it can be inserted
+    /// to maintain the sort. See [`slice::binary_search_by_key`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -112,9 +112,11 @@ impl<T> Slice<T> {
 
     /// Search over a sorted set for a value.
     ///
-    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
-    /// see [slice::binary_search] for more details.
-    /// **O(log(n))**, which is notably less scalable than looking the value up in the set this is a slice from.
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// see [`slice::binary_search`] for more details.
+    ///
+    /// Computes in **O(log(n))** time,
+    /// which is notably less scalable than looking the value up in the set this is a slice from.
     pub fn binary_search(&self, x: &T) -> Result<usize, usize>
     where
         T: Ord,
@@ -124,9 +126,10 @@ impl<T> Slice<T> {
 
     /// Search over a sorted set with a comparator function.
     ///
-    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
-    /// see [slice::binary_search_by] for more details.
-    /// **O(log(n))**
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// see [`slice::binary_search_by`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[inline]
     pub fn binary_search_by<'a, F>(&'a self, mut f: F) -> Result<usize, usize>
     where
@@ -135,11 +138,12 @@ impl<T> Slice<T> {
         self.entries.binary_search_by(move |a| f(&a.key))
     }
 
-    /// Search over a sorted set with a key extraction function.
+    /// Search over a sorted set with an extraction function.
     ///
-    /// Returns the position where that value is present, or the position where can be inserted to maintain the sort.
-    /// see [slice::binary_search_by_key] for more details.
-    /// **O(log(n))**
+    /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
+    /// see [`slice::binary_search_by_key`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[inline]
     pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, mut f: F) -> Result<usize, usize>
     where
@@ -149,11 +153,12 @@ impl<T> Slice<T> {
         self.binary_search_by(|k| f(k).cmp(b))
     }
 
-    /// Returns the index of the partition point or a sorted set according to the given predicate
+    /// Returns the index of the partition point of a sorted set according to the given predicate
     /// (the index of the first element of the second partition).
     ///
-    /// see [slice::partition_point] for more details.
-    /// **O(log(n))**
+    /// see [`slice::partition_point`] for more details.
+    ///
+    /// Computes in **O(log(n))** time.
     #[must_use]
     pub fn partition_point<P>(&self, mut pred: P) -> usize
     where

--- a/src/set/slice.rs
+++ b/src/set/slice.rs
@@ -113,7 +113,7 @@ impl<T> Slice<T> {
     /// Search over a sorted set for a value.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// see [`slice::binary_search`] for more details.
+    /// See [`slice::binary_search`] for more details.
     ///
     /// Computes in **O(log(n))** time,
     /// which is notably less scalable than looking the value up in the set this is a slice from.
@@ -127,7 +127,7 @@ impl<T> Slice<T> {
     /// Search over a sorted set with a comparator function.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// see [`slice::binary_search_by`] for more details.
+    /// See [`slice::binary_search_by`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -141,7 +141,7 @@ impl<T> Slice<T> {
     /// Search over a sorted set with an extraction function.
     ///
     /// Returns the position where that value is present, or the position where it can be inserted to maintain the sort.
-    /// see [`slice::binary_search_by_key`] for more details.
+    /// See [`slice::binary_search_by_key`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[inline]
@@ -156,7 +156,7 @@ impl<T> Slice<T> {
     /// Returns the index of the partition point of a sorted set according to the given predicate
     /// (the index of the first element of the second partition).
     ///
-    /// see [`slice::partition_point`] for more details.
+    /// See [`slice::partition_point`] for more details.
     ///
     /// Computes in **O(log(n))** time.
     #[must_use]

--- a/src/set/tests.rs
+++ b/src/set/tests.rs
@@ -546,7 +546,7 @@ fn iter_default() {
 
 #[test]
 fn test_binary_search_by() {
-    // addaped from stds test for binary_search
+    // adapted from std's test for binary_search
     let b: IndexSet<i32> = [].into();
     assert_eq!(b.binary_search_by(|x| x.cmp(&5)), Err(0));
 
@@ -577,7 +577,7 @@ fn test_binary_search_by() {
     assert_eq!(b.binary_search_by(|x| x.cmp(&0)), Err(0));
     assert_eq!(b.binary_search_by(|x| x.cmp(&1)), Ok(0));
     assert_eq!(b.binary_search_by(|x| x.cmp(&2)), Err(1));
-    // diff from std as set the duplicates keys
+    // diff from std as set merges the duplicate keys
     assert!(match b.binary_search_by(|x| x.cmp(&3)) {
         Ok(1..=2) => true,
         _ => false,
@@ -595,7 +595,7 @@ fn test_binary_search_by() {
 
 #[test]
 fn test_binary_search_by_key() {
-    // addaped from stds test for binary_search
+    // adapted from std's test for binary_search
     let b: IndexSet<i32> = [].into();
     assert_eq!(b.binary_search_by_key(&5, |&x| x), Err(0));
 
@@ -626,7 +626,7 @@ fn test_binary_search_by_key() {
     assert_eq!(b.binary_search_by_key(&0, |&x| x), Err(0));
     assert_eq!(b.binary_search_by_key(&1, |&x| x), Ok(0));
     assert_eq!(b.binary_search_by_key(&2, |&x| x), Err(1));
-    // diff from std as set the duplicates keys
+    // diff from std as set merges the duplicate keys
     assert!(match b.binary_search_by_key(&3, |&x| x) {
         Ok(1..=2) => true,
         _ => false,
@@ -644,7 +644,7 @@ fn test_binary_search_by_key() {
 
 #[test]
 fn test_partition_point() {
-    // addaped from stds test for partition_point
+    // adapted from std's test for partition_point
     let b: IndexSet<i32> = [].into();
     assert_eq!(b.partition_point(|&x| x < 5), 0);
 
@@ -676,7 +676,7 @@ fn test_partition_point() {
     assert_eq!(b.partition_point(|&x| x < 1), 0);
     assert_eq!(b.partition_point(|&x| x < 2), 1);
     assert_eq!(b.partition_point(|&x| x < 3), 1);
-    assert_eq!(b.partition_point(|&x| x < 4), 2); // diff from std as set the duplicates keys
+    assert_eq!(b.partition_point(|&x| x < 4), 2); // diff from std as set merges the duplicate keys
     assert_eq!(b.partition_point(|&x| x < 5), 2);
     assert_eq!(b.partition_point(|&x| x < 6), 2);
     assert_eq!(b.partition_point(|&x| x < 7), 2);

--- a/src/set/tests.rs
+++ b/src/set/tests.rs
@@ -543,3 +543,142 @@ fn iter_default() {
     assert_default::<Iter<'static, Item>>();
     assert_default::<IntoIter<Item>>();
 }
+
+#[test]
+fn test_binary_search_by() {
+    // addaped from stds test for binary_search
+    let b: IndexSet<i32> = [].into();
+    assert_eq!(b.binary_search_by(|x| x.cmp(&5)), Err(0));
+
+    let b: IndexSet<i32> = [4].into();
+    assert_eq!(b.binary_search_by(|x| x.cmp(&3)), Err(0));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&4)), Ok(0));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&5)), Err(1));
+
+    let b: IndexSet<i32> = [1, 2, 4, 6, 8, 9].into();
+    assert_eq!(b.binary_search_by(|x| x.cmp(&5)), Err(3));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&6)), Ok(3));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&7)), Err(4));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&8)), Ok(4));
+
+    let b: IndexSet<i32> = [1, 2, 4, 5, 6, 8].into();
+    assert_eq!(b.binary_search_by(|x| x.cmp(&9)), Err(6));
+
+    let b: IndexSet<i32> = [1, 2, 4, 6, 7, 8, 9].into();
+    assert_eq!(b.binary_search_by(|x| x.cmp(&6)), Ok(3));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&5)), Err(3));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&8)), Ok(5));
+
+    let b: IndexSet<i32> = [1, 2, 4, 5, 6, 8, 9].into();
+    assert_eq!(b.binary_search_by(|x| x.cmp(&7)), Err(5));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&0)), Err(0));
+
+    let b: IndexSet<i32> = [1, 3, 3, 3, 7].into();
+    assert_eq!(b.binary_search_by(|x| x.cmp(&0)), Err(0));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&1)), Ok(0));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&2)), Err(1));
+    // diff from std as set the duplicates keys
+    assert!(match b.binary_search_by(|x| x.cmp(&3)) {
+        Ok(1..=2) => true,
+        _ => false,
+    });
+    assert!(match b.binary_search_by(|x| x.cmp(&3)) {
+        Ok(1..=2) => true,
+        _ => false,
+    });
+    assert_eq!(b.binary_search_by(|x| x.cmp(&4)), Err(2));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&5)), Err(2));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&6)), Err(2));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&7)), Ok(2));
+    assert_eq!(b.binary_search_by(|x| x.cmp(&8)), Err(3));
+}
+
+#[test]
+fn test_binary_search_by_key() {
+    // addaped from stds test for binary_search
+    let b: IndexSet<i32> = [].into();
+    assert_eq!(b.binary_search_by_key(&5, |&x| x), Err(0));
+
+    let b: IndexSet<i32> = [4].into();
+    assert_eq!(b.binary_search_by_key(&3, |&x| x), Err(0));
+    assert_eq!(b.binary_search_by_key(&4, |&x| x), Ok(0));
+    assert_eq!(b.binary_search_by_key(&5, |&x| x), Err(1));
+
+    let b: IndexSet<i32> = [1, 2, 4, 6, 8, 9].into();
+    assert_eq!(b.binary_search_by_key(&5, |&x| x), Err(3));
+    assert_eq!(b.binary_search_by_key(&6, |&x| x), Ok(3));
+    assert_eq!(b.binary_search_by_key(&7, |&x| x), Err(4));
+    assert_eq!(b.binary_search_by_key(&8, |&x| x), Ok(4));
+
+    let b: IndexSet<i32> = [1, 2, 4, 5, 6, 8].into();
+    assert_eq!(b.binary_search_by_key(&9, |&x| x), Err(6));
+
+    let b: IndexSet<i32> = [1, 2, 4, 6, 7, 8, 9].into();
+    assert_eq!(b.binary_search_by_key(&6, |&x| x), Ok(3));
+    assert_eq!(b.binary_search_by_key(&5, |&x| x), Err(3));
+    assert_eq!(b.binary_search_by_key(&8, |&x| x), Ok(5));
+
+    let b: IndexSet<i32> = [1, 2, 4, 5, 6, 8, 9].into();
+    assert_eq!(b.binary_search_by_key(&7, |&x| x), Err(5));
+    assert_eq!(b.binary_search_by_key(&0, |&x| x), Err(0));
+
+    let b: IndexSet<i32> = [1, 3, 3, 3, 7].into();
+    assert_eq!(b.binary_search_by_key(&0, |&x| x), Err(0));
+    assert_eq!(b.binary_search_by_key(&1, |&x| x), Ok(0));
+    assert_eq!(b.binary_search_by_key(&2, |&x| x), Err(1));
+    // diff from std as set the duplicates keys
+    assert!(match b.binary_search_by_key(&3, |&x| x) {
+        Ok(1..=2) => true,
+        _ => false,
+    });
+    assert!(match b.binary_search_by_key(&3, |&x| x) {
+        Ok(1..=2) => true,
+        _ => false,
+    });
+    assert_eq!(b.binary_search_by_key(&4, |&x| x), Err(2));
+    assert_eq!(b.binary_search_by_key(&5, |&x| x), Err(2));
+    assert_eq!(b.binary_search_by_key(&6, |&x| x), Err(2));
+    assert_eq!(b.binary_search_by_key(&7, |&x| x), Ok(2));
+    assert_eq!(b.binary_search_by_key(&8, |&x| x), Err(3));
+}
+
+#[test]
+fn test_partition_point() {
+    // addaped from stds test for partition_point
+    let b: IndexSet<i32> = [].into();
+    assert_eq!(b.partition_point(|&x| x < 5), 0);
+
+    let b: IndexSet<_> = [4].into();
+    assert_eq!(b.partition_point(|&x| x < 3), 0);
+    assert_eq!(b.partition_point(|&x| x < 4), 0);
+    assert_eq!(b.partition_point(|&x| x < 5), 1);
+
+    let b: IndexSet<_> = [1, 2, 4, 6, 8, 9].into();
+    assert_eq!(b.partition_point(|&x| x < 5), 3);
+    assert_eq!(b.partition_point(|&x| x < 6), 3);
+    assert_eq!(b.partition_point(|&x| x < 7), 4);
+    assert_eq!(b.partition_point(|&x| x < 8), 4);
+
+    let b: IndexSet<_> = [1, 2, 4, 5, 6, 8].into();
+    assert_eq!(b.partition_point(|&x| x < 9), 6);
+
+    let b: IndexSet<_> = [1, 2, 4, 6, 7, 8, 9].into();
+    assert_eq!(b.partition_point(|&x| x < 6), 3);
+    assert_eq!(b.partition_point(|&x| x < 5), 3);
+    assert_eq!(b.partition_point(|&x| x < 8), 5);
+
+    let b: IndexSet<_> = [1, 2, 4, 5, 6, 8, 9].into();
+    assert_eq!(b.partition_point(|&x| x < 7), 5);
+    assert_eq!(b.partition_point(|&x| x < 0), 0);
+
+    let b: IndexSet<_> = [1, 3, 3, 3, 7].into();
+    assert_eq!(b.partition_point(|&x| x < 0), 0);
+    assert_eq!(b.partition_point(|&x| x < 1), 0);
+    assert_eq!(b.partition_point(|&x| x < 2), 1);
+    assert_eq!(b.partition_point(|&x| x < 3), 1);
+    assert_eq!(b.partition_point(|&x| x < 4), 2); // diff from std as set the duplicates keys
+    assert_eq!(b.partition_point(|&x| x < 5), 2);
+    assert_eq!(b.partition_point(|&x| x < 6), 2);
+    assert_eq!(b.partition_point(|&x| x < 7), 2);
+    assert_eq!(b.partition_point(|&x| x < 8), 3);
+}


### PR DESCRIPTION
This is a start on fixing #281.

I copied the implementation of these methods from std, except for `binary_search_by` where I used std directly. Alternatively we could have all implementations directly forward to `.as_slice().foobar` or `.entries.foobar`,  if you would prefer that.

I left off the plane `binary_search{_keys}` on set and map, because they already provide a `O(1)` way to look up the index for a key. I left them in on `Slice` because they do not.

For documentation I adapted the first sentence of std, and provided a link to std.

how would you like to see these tested?