### PR TITLE
`impl Index<usize> for Keys`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1079,6 +1079,10 @@ where
 
 /// Access `IndexMap` values at indexed positions.
 ///
+/// See [`Index<usize> for Keys`][keys] to access a map's keys instead.
+///
+/// [keys]: Keys#impl-Index<usize>-for-Keys<'a,+K,+V>
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
While `Index<usize> for IndexMap` accesses a map's values, indexing through `IndexMap::keys` offers an alternative to access a map's keys instead.

Resolves #284.