### PR TITLE
Implement the Merge Crate for IndexMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 rayon = { version = "1.5.3", optional = true }
+# default-features = false ensures the entire crate stays non-std
+merge = {version="0.1", optional = true, default-features = false}
 
 # Internal feature, only used when building as part of rustc,
 # not part of the stable interface of this crate.
@@ -40,8 +42,9 @@ fxhash = "0.2.1"
 serde_derive = "1.0"
 
 [features]
-default = ["std"]
+default = ["std", "merge"]
 std = []
+merge = ["dep:merge"]
 
 # for testing only, of course
 test_debug = []
@@ -54,7 +57,7 @@ no-dev-version = true
 tag-name = "{{version}}"
 
 [package.metadata.docs.rs]
-features = ["arbitrary", "quickcheck", "serde", "rayon"]
+features = ["arbitrary", "quickcheck", "serde", "rayon", "merge"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]

--- a/src/map.rs
+++ b/src/map.rs
@@ -98,7 +98,7 @@ where
     S: BuildHasher,
 {
     /// Note: If any of the rows have the same key, then they wont be merged.
-    /// the value on the right will be preserved.
+    /// the value on the left will be preserved.
     /// 
     /// ```
     /// use indexmap::IndexMap;

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -668,3 +668,33 @@ fn test_partition_point() {
     assert_eq!(b.partition_point(|_, &x| x < 7), 4);
     assert_eq!(b.partition_point(|_, &x| x < 8), 5);
 }
+
+#[cfg(feature = "merge")]
+#[test]
+fn merge() {
+    // Joinked from the merge crate tests
+    fn test<T: std::fmt::Debug + Merge + PartialEq>(expected: T, mut left: T, right: T) {
+        left.merge(right);
+        assert_eq!(expected, left);
+    }
+
+    let expected: IndexMap<_, i32> = [1, 3, 3, 3, 7, 1, 3, 3, 3, 7]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+
+    let a: IndexMap<_, i32> = [1, 3, 3, 3, 7]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 100, x))
+        .collect();
+
+    let b: IndexMap<_, i32> = [1, 3, 3, 3, 7]
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| (i + 105, x)) // Key must be different, see merge doc
+        .collect();
+
+    test(expected, a, b);
+}


### PR DESCRIPTION
I made sure to include tests and docs, with everything passing.

### The doc of the function:
Note: If any of the rows have the same key, then they wont be merged.
the values on the right will be preserved.
```rust 
use indexmap::IndexMap;
// You need the merge crate, this crate does not re-export it.
use merge::Merge;

let expected: IndexMap<_, i32> = [("Hello", 1), ("Hi", 50), ("Ello", 2)]
    .into_iter()
    .collect();

let mut a: IndexMap<_, i32> = [("Hello", 1), ("Hi", 50)]
    .into_iter()
    .collect();

let b: IndexMap<_, i32> = [("Ello", 2), ("Hi", 2)]
    .into_iter()
    .collect();

a.merge(b);
// Note how `("Hi", 2)` in `b` wont replace `("Hi", 50)` in `a`.
// Things in `b` will be ordered after `a`
assert_eq!(expected, a);
```

The feature was also gated behind a feature flag, specifically `merge`.
All crates that I added are configured to be non-std.

Should fix #286 