### PR TITLE
Add method to get a map entry by index

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -32,7 +32,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use std::collections::hash_map::RandomState;
 
-use self::core::IndexMapCore;
+use self::core::{IndexMapCore, IndexedEntry};
 use crate::util::{third, try_simplify_range};
 use crate::{Bucket, Entries, Equivalent, HashValue, TryReserveError};
 
@@ -421,6 +421,18 @@ where
     pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
         let hash = self.hash(&key);
         self.core.entry(hash, key)
+    }
+
+    /// Get an entry in the map by index for in-place manipulation.
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    ///
+    /// Computes in **O(1)** time.
+    pub fn get_index_entry(&mut self, index: usize) -> Option<IndexedEntry<'_, K, V>> {
+        if index >= self.len() {
+            return None;
+        }
+        Some(IndexedEntry::new(&mut self.core, index))
     }
 
     /// Return `true` if an equivalent to `key` exists in the map.

--- a/src/map.rs
+++ b/src/map.rs
@@ -423,18 +423,6 @@ where
         self.core.entry(hash, key)
     }
 
-    /// Get an entry in the map by index for in-place manipulation.
-    ///
-    /// Valid indices are *0 <= index < self.len()*
-    ///
-    /// Computes in **O(1)** time.
-    pub fn get_index_entry(&mut self, index: usize) -> Option<IndexedEntry<'_, K, V>> {
-        if index >= self.len() {
-            return None;
-        }
-        Some(IndexedEntry::new(&mut self.core, index))
-    }
-
     /// Return `true` if an equivalent to `key` exists in the map.
     ///
     /// Computes in **O(1)** time (average).
@@ -909,6 +897,18 @@ impl<K, V, S> IndexMap<K, V, S> {
     /// Computes in **O(1)** time.
     pub fn get_index_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
         self.as_entries_mut().get_mut(index).map(Bucket::ref_mut)
+    }
+
+    /// Get an entry in the map by index for in-place manipulation.
+    ///
+    /// Valid indices are *0 <= index < self.len()*
+    ///
+    /// Computes in **O(1)** time.
+    pub fn get_index_entry(&mut self, index: usize) -> Option<IndexedEntry<'_, K, V>> {
+        if index >= self.len() {
+            return None;
+        }
+        Some(IndexedEntry::new(&mut self.core, index))
     }
 
     /// Returns a slice of key-value pairs in the given range of indices.

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -360,6 +360,36 @@ fn occupied_entry_key() {
 }
 
 #[test]
+fn get_index_entry() {
+    let mut map = IndexMap::new();
+
+    assert!(map.get_index_entry(0).is_none());
+
+    map.insert(0, "0");
+    map.insert(1, "1");
+    map.insert(2, "2");
+    map.insert(3, "3");
+
+    assert!(map.get_index_entry(4).is_none());
+
+    {
+        let e = map.get_index_entry(1).unwrap();
+        assert_eq!(*e.key(), 1);
+        assert_eq!(*e.get(), "1");
+        assert_eq!(e.swap_remove(), "1");
+    }
+
+    {
+        let mut e = map.get_index_entry(1).unwrap();
+        assert_eq!(*e.key(), 3);
+        assert_eq!(*e.get(), "3");
+        assert_eq!(e.insert("4"), "3");
+    }
+
+    assert_eq!(*map.get(&3).unwrap(), "4");
+}
+
+#[test]
 fn keys() {
     let vec = vec![(1, 'a'), (2, 'b'), (3, 'c')];
     let map: IndexMap<_, _> = vec.into_iter().collect();


### PR DESCRIPTION
This change adds a method `get_index_entry` to `IndexMap`, which is the by-index counterpart to `entry`. The returned struct `IndexedEntry` provides the same methods as `OccupiedEntry`, except `replace_key`.

A concrete use case where I found this useful is having a `map: IndexMap<_, Vec<_>>` with the invariant that each `Vec` is non-empty. Imagine we want to pick an entry at a random index and pop a value from the `Vec`. Without this change we'd have to use `get_mut_index` and `swap_remove_index`, and ensure that we use the same index. With `get_index_entry` we can write:

```rust
let mut e = map.get_index_entry(index).unwrap();
let v = e.get_mut();
let x = v.pop().unwrap();
if v.is_empty() {
    e.swap_remove();
}
```