### PR TITLE
Remove doc `html_root_url`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // We *mostly* avoid unsafe code, but `map::core::raw` allows it to use `RawTable` buckets.
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
-#![doc(html_root_url = "https://docs.rs/indexmap/1/")]
 #![no_std]
 
 //! [`IndexMap`] is a hash table where the iteration order of the key-value


### PR DESCRIPTION
The `html_root_url` currently links to an old version of the docs, so if you run `cargo doc --no-deps` on a downstream package that depends on `indexmap@2.1.0`, intra-doc links to `indexmap` types will resolve to `indexmap@1.9.3` on docs.rs.