### PR TITLE
Relax some over-constrained impl bounds

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -316,13 +316,7 @@ impl<K, V, S> IndexMap<K, V, S> {
             hash_builder: self.hash_builder.clone(),
         }
     }
-}
 
-impl<K, V, S> IndexMap<K, V, S>
-where
-    K: Hash + Eq,
-    S: BuildHasher,
-{
     /// Reserve capacity for `additional` more key-value pairs.
     ///
     /// Computes in **O(n)** time.
@@ -374,13 +368,13 @@ where
     pub fn shrink_to(&mut self, min_capacity: usize) {
         self.core.shrink_to(min_capacity);
     }
+}
 
-    fn hash<Q: ?Sized + Hash>(&self, key: &Q) -> HashValue {
-        let mut h = self.hash_builder.build_hasher();
-        key.hash(&mut h);
-        HashValue(h.finish() as usize)
-    }
-
+impl<K, V, S> IndexMap<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher,
+{
     /// Insert a key-value pair in the map.
     ///
     /// If an equivalent key already exists in the map: the key remains and
@@ -423,6 +417,17 @@ where
     pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
         let hash = self.hash(&key);
         self.core.entry(hash, key)
+    }
+}
+
+impl<K, V, S> IndexMap<K, V, S>
+where
+    S: BuildHasher,
+{
+    fn hash<Q: ?Sized + Hash>(&self, key: &Q) -> HashValue {
+        let mut h = self.hash_builder.build_hasher();
+        key.hash(&mut h);
+        HashValue(h.finish() as usize)
     }
 
     /// Return `true` if an equivalent to `key` exists in the map.
@@ -663,7 +668,9 @@ where
         let hash = self.hash(key);
         self.core.shift_remove_full(hash, key)
     }
+}
 
+impl<K, V, S> IndexMap<K, V, S> {
     /// Remove the last key-value pair
     ///
     /// This preserves the order of the remaining elements.
@@ -861,9 +868,7 @@ where
     pub fn reverse(&mut self) {
         self.core.reverse()
     }
-}
 
-impl<K, V, S> IndexMap<K, V, S> {
     /// Returns a slice of all the key-value pairs in the map.
     ///
     /// Computes in **O(1)** time.
@@ -1037,7 +1042,6 @@ impl<K, V, S> IndexMap<K, V, S> {
 impl<K, V, Q: ?Sized, S> Index<&Q> for IndexMap<K, V, S>
 where
     Q: Hash + Equivalent<K>,
-    K: Hash + Eq,
     S: BuildHasher,
 {
     type Output = V;
@@ -1082,7 +1086,6 @@ where
 impl<K, V, Q: ?Sized, S> IndexMut<&Q> for IndexMap<K, V, S>
 where
     Q: Hash + Equivalent<K>,
-    K: Hash + Eq,
     S: BuildHasher,
 {
     /// Returns a mutable reference to the value corresponding to the supplied `key`.

--- a/src/map/serde_seq.rs
+++ b/src/map/serde_seq.rs
@@ -75,9 +75,8 @@ where
 /// ```
 pub fn serialize<K, V, S, T>(map: &IndexMap<K, V, S>, serializer: T) -> Result<T::Ok, T::Error>
 where
-    K: Serialize + Hash + Eq,
+    K: Serialize,
     V: Serialize,
-    S: BuildHasher,
     T: Serializer,
 {
     serializer.collect_seq(map)

--- a/src/mutable_keys.rs
+++ b/src/mutable_keys.rs
@@ -54,7 +54,6 @@ pub trait MutableKeys: private::Sealed {
 /// See [`MutableKeys`] for more information.
 impl<K, V, S> MutableKeys for IndexMap<K, V, S>
 where
-    K: Eq + Hash,
     S: BuildHasher,
 {
     type Key = K;

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -408,9 +408,8 @@ where
 
 impl<K, V, S> IndexMap<K, V, S>
 where
-    K: Hash + Eq + Send,
+    K: Send,
     V: Send,
-    S: BuildHasher,
 {
     /// Sort the map’s key-value pairs in parallel, by the default ordering of the keys.
     pub fn par_sort_keys(&mut self)

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -484,8 +484,7 @@ where
 /// The following methods **require crate feature `"rayon"`**.
 impl<T, S> IndexSet<T, S>
 where
-    T: Hash + Eq + Send,
-    S: BuildHasher + Send,
+    T: Send,
 {
     /// Sort the set’s values in parallel by their default ordering.
     pub fn par_sort(&mut self)

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -14,9 +14,8 @@ use crate::IndexMap;
 
 impl<K, V, S> Serialize for IndexMap<K, V, S>
 where
-    K: Serialize + Hash + Eq,
+    K: Serialize,
     V: Serialize,
-    S: BuildHasher,
 {
     fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
     where
@@ -87,8 +86,7 @@ use crate::IndexSet;
 
 impl<T, S> Serialize for IndexSet<T, S>
 where
-    T: Serialize + Hash + Eq,
-    S: BuildHasher,
+    T: Serialize,
 {
     fn serialize<Se>(&self, serializer: Se) -> Result<Se::Ok, Se::Error>
     where


### PR DESCRIPTION
Most of these are removing `K: Hash + Eq` and/or `S: BuildHasher` where
we don't actually need to hash anything.

In some cases, we only get away with that because we have a saved hash
in each entry `Bucket`. I *suspect* we still kept the constraints as API
protection, in case we ever wanted to change our mind and stop saving
the hash. However, there are a few other unconstrained methods that also
need the saved hash, like `swap_remove_index` going back long before
version 1.0 of the crate, so that ship has sailed.
